### PR TITLE
Fix RenovateBot Workflow Dispatch Call

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -6,6 +6,11 @@ on:
     branches:
       - dev
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run on'
+        default: 'dev'
+        required: true
 
 permissions:
   contents: write
@@ -23,9 +28,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v40.2.10
+        uses: renovatebot/github-action@v40.3.5
         with:
           token: '${{ steps.app-token.outputs.token }}'
           docker-user: root


### PR DESCRIPTION
The workflow dispatch can be run on a branch but it doesn't checkout the code from that branch currently. Makes testing this difficult