### PR TITLE
fix(package.yaml): deploy key to exempt action from br protection rules

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -25,6 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.sha }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup | Force correct release branch on workflow sha
         run: |


### PR DESCRIPTION
Semantic release cannot commit to alpha the version change because the branch protection requiring a PR. We don't want to remove that rule, so using a deploy key and adding deploy keys to the exemption list in the branch protections _should_ hopefully work.