### PR TITLE
Remove double logging

### DIFF
--- a/src/cpg_flow/utils.py
+++ b/src/cpg_flow/utils.py
@@ -61,7 +61,7 @@ def get_logger(
             coloredlogs.install(level=log_level, fmt=fmt_string, logger=new_logger)
 
         # create a stream handler to write output
-        stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler = logging.StreamHandler()
         stream_handler.setLevel(log_level)
 
         # create format string for messages


### PR DESCRIPTION
The default python logger writes to sys.stderr. By adding a log handler that writes to sys.stdout, the logging library writes everything twice, once to each stream.

Fixed and tested in prod-pipes ([ref](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/utils.py#L69))