### PR TITLE
Custom download artifact

### DIFF
--- a/.github/workflows/update-badges.yaml
+++ b/.github/workflows/update-badges.yaml
@@ -17,10 +17,34 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
 
-      - name: "Load badge data"
-        uses: actions/download-artifact@v4
+      - name: 'Download badge data'
+        uses: actions/github-script@v6
         with:
-          name: badge-data
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "badge-data";
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/artifacts';
+            if (!fs.existsSync(temp)){
+              fs.mkdirSync(temp);
+            }
+            fs.writeFileSync(path.join(temp, 'badge_data.zip'), Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip badge_data.zip -d "${{ runner.temp }}/artifacts"
 
       - name: "Load badge data environment variables"
         run: |


### PR DESCRIPTION
According to github you can access artifacts from other workflow. But you cannot use their download-artifact action. Have to use this script. See here:
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run