### PR TITLE
fix(Workflow): catch the correct ConnectionError and rm useless log line

### DIFF
--- a/src/cpg_flow/workflow.py
+++ b/src/cpg_flow/workflow.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import networkx as nx
 import plotly.io as pio
+from requests.exceptions import ConnectionError
 
 from cpg_flow.inputs import get_multicohort
 from cpg_flow.show_workflow.graph import GraphPlot
@@ -269,6 +270,8 @@ class Workflow:
 
         if not self.dry_run:
             get_batch().run(wait=wait)
+        else:
+            LOGGER.info('Dry run: no jobs submitted')
 
     @staticmethod
     def _process_first_last_stages(
@@ -523,9 +526,6 @@ class Workflow:
                     raise WorkflowError(
                         f'Stage {stg} failed to queue jobs with errors: ' + '\n'.join(errors),
                     )
-
-                LOGGER.info('')
-
         else:
             self.queued_stages = [stg for stg in _stages_d.values() if not stg.skipped]
             LOGGER.info(f'Queued stages: {self.queued_stages}')


### PR DESCRIPTION
This change was motivated by the local dry_run of cpg-flow always failing by attempting to contact metamist.
By catching the appropriate error this is no longer the case. We also log a final line with dry_run complete.

SET-448