### PR TITLE
Add path to mkdocs config file

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -62,4 +62,4 @@ jobs:
 
       - name: Publish | Update docs version
         run: |
-          uv run mike deploy --push --update-aliases ${{ steps.release.outputs.tag }} latest
+          uv run mike deploy -F docs/mkdocs.yml --push --update-aliases ${{ steps.release.outputs.tag }} latest


### PR DESCRIPTION
This should fix the broken package deploys we have since we introduced versioning.

https://github.com/populationgenomics/cpg-flow/actions/workflows/package.yaml

