### PR TITLE
Add dataset attribute to Cohort target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,11 +24,12 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.3
+    rev: v0.11.2
     hooks:
-      - id: ruff
+      - id: ruff-format
         name: ruff (format)
-        args: [--fix]
+      - id: ruff
+        name: ruff (lint)
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,8 +153,6 @@ ignore = [
     "ANN001",
     "ANN002",
     "ANN003",
-    "ANN101",  # Missing type annotation for self in method
-    "ANN102",  # Missing type annotation for `cls` in classmethod
     "ANN201",  # Missing return type annotation for public function
     "ANN202",
     "ANN204",  # Missing type annotation for special method `__init__`
@@ -275,7 +273,6 @@ ignore = [
     "UP015",
     "UP020",
     "UP026",
-    "UP027",
     "UP030",
     "UP031",
     "UP032",

--- a/src/cpg_flow/__init__.py
+++ b/src/cpg_flow/__init__.py
@@ -13,4 +13,4 @@ Modules:
 This package is designed to be used with pdoc for generating documentation.
 """
 
-__all__ = ['targets', 'stage', 'workflow']
+__all__ = ['stage', 'targets', 'workflow']

--- a/src/cpg_flow/filetypes.py
+++ b/src/cpg_flow/filetypes.py
@@ -41,9 +41,10 @@ class CramOrBamPath(AlignmentInput, ABC):
         self.full_index_suffix: str | None = None
         if index_path:
             self.index_path = to_path(index_path)
-            assert self.index_path.suffix == f".{self.index_ext}"
+            assert self.index_path.suffix == f'.{self.index_ext}'
             self.full_index_suffix = str(self.index_path).replace(
-                str(self.path.with_suffix("")), "",
+                str(self.path.with_suffix('')),
+                '',
             )
         self.reference_assembly = None
         if reference_assembly:
@@ -70,8 +71,8 @@ class CramOrBamPath(AlignmentInput, ABC):
         res = str(self.path)
         if self.index_path:
             assert self.full_index_suffix
-            res += f"+{self.full_index_suffix}"
-        return f"{self.ext.upper()}({res})"
+            res += f'+{self.full_index_suffix}'
+        return f'{self.ext.upper()}({res})'
 
     def exists(self) -> bool:
         """
@@ -97,8 +98,8 @@ class BamPath(CramOrBamPath):
     Represents a path to a BAM file, optionally with corresponding index.
     """
 
-    EXT = "bam"
-    INDEX_EXT = "bai"
+    EXT = 'bam'
+    INDEX_EXT = 'bai'
 
     def __init__(
         self,
@@ -121,8 +122,8 @@ class CramPath(CramOrBamPath):
     Represents a path to a CRAM file, optionally with corresponding index.
     """
 
-    EXT = "cram"
-    INDEX_EXT = "crai"
+    EXT = 'cram'
+    INDEX_EXT = 'crai'
 
     def __init__(
         self,
@@ -131,7 +132,7 @@ class CramPath(CramOrBamPath):
         reference_assembly: str | Path | None = None,
     ):
         super().__init__(path, index_path, reference_assembly)
-        self.somalier_path = to_path(f"{self.path}.somalier")
+        self.somalier_path = to_path(f'{self.path}.somalier')
 
     @property
     def ext(self) -> str:
@@ -151,13 +152,13 @@ class GvcfPath:
 
     def __init__(self, path: Path | str):
         self.path = to_path(path)
-        self.somalier_path = to_path(f"{self.path}.somalier")
+        self.somalier_path = to_path(f'{self.path}.somalier')
 
     def __str__(self) -> str:
         return str(self.path)
 
     def __repr__(self) -> str:
-        return f"GVCF({self.path})"
+        return f'GVCF({self.path})'
 
     def exists(self) -> bool:
         """
@@ -170,7 +171,7 @@ class GvcfPath:
         """
         Path to the corresponding index
         """
-        return to_path(f"{self.path}.tbi")
+        return to_path(f'{self.path}.tbi')
 
     def resource_group(self, b: Batch) -> ResourceGroup:
         """
@@ -178,8 +179,8 @@ class GvcfPath:
         """
         return b.read_input_group(
             **{
-                "g.vcf.gz": str(self.path),
-                "g.vcf.gz.tbi": str(self.tbi_path),
+                'g.vcf.gz': str(self.path),
+                'g.vcf.gz.tbi': str(self.tbi_path),
             },
         )
 
@@ -200,19 +201,12 @@ class FastqPair(AlignmentInput):
         assert i == 0 or i == 1, i
         return [self.r1, self.r2][i]
 
-    def as_resources(self, b) -> "FastqPair":
+    def as_resources(self, b) -> 'FastqPair':
         """
         Makes a pair of ResourceFile objects for r1 and r2.
         """
         return FastqPair(
-            *[
-                (
-                    self[i]
-                    if isinstance(self[i], ResourceFile)
-                    else b.read_input(str(self[i]))
-                )
-                for i in [0, 1]
-            ],
+            *[(self[i] if isinstance(self[i], ResourceFile) else b.read_input(str(self[i]))) for i in [0, 1]],
         )
 
     def exists(self) -> bool:
@@ -228,7 +222,7 @@ class FastqPair(AlignmentInput):
         >>> str(FastqPair('gs://sequencing_group_R1.fq.gz', 'gs://sequencing_group_R2.fq.gz'))
         'gs://sequencing_group_R{1,2}.fq.gz'
         """
-        return "".join(
+        return ''.join(
             f'{{{",".join(sorted(set(chars)))}}}' if len(set(chars)) > 1 else chars[0]
             for chars in zip(str(self.r1), str(self.r2), strict=False)
         )
@@ -257,7 +251,7 @@ class FastqPairs(list[FastqPair], AlignmentInput):
         >>> repr(FastqPairs([p1, p2]))
         'gs://sequencing_group_L{1,2}_R{1,2}.fq.gz'
         """
-        return "".join(
+        return ''.join(
             f'{{{",".join(sorted(set(chars)))}}}' if len(set(chars)) > 1 else chars[0]
             for chars in zip(*[repr(pair) for pair in self], strict=False)
         )

--- a/src/cpg_flow/inputs.py
+++ b/src/cpg_flow/inputs.py
@@ -111,13 +111,18 @@ def create_multicohort() -> MultiCohort:
         # dataset_id is sequencing_group_dict['sample']['project']['name']
         cohort_sg_dict = get_cohort_sgs(cohort_id)
         cohort_name = cohort_sg_dict.get('name', cohort_id)
+        cohort_dataset = cohort_sg_dict.get('dataset', None)
         cohort_sgs = cohort_sg_dict.get('sequencing_groups', [])
 
         if len(cohort_sgs) == 0:
             raise MetamistError(f'Cohort {cohort_id} has no sequencing groups')
 
         # create a new Cohort object
-        cohort = multicohort.create_cohort(id=cohort_id, name=cohort_name)
+        cohort = multicohort.create_cohort(
+            id=cohort_id,
+            name=cohort_name,
+            dataset=cohort_dataset,
+        )
 
         # first populate these SGs into their Datasets
         # required so that the SG objects can be referenced in the collective Datasets

--- a/src/cpg_flow/inputs.py
+++ b/src/cpg_flow/inputs.py
@@ -278,6 +278,5 @@ def _populate_pedigree(dataset: Dataset) -> None:
         )
     if sgids_wo_ped:
         LOGGER.warning(
-            f'No pedigree data found for '
-            f'{len(sgids_wo_ped)}/{len(dataset.get_sequencing_groups())} sequencing groups',
+            f'No pedigree data found for {len(sgids_wo_ped)}/{len(dataset.get_sequencing_groups())} sequencing groups',
         )

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -64,6 +64,9 @@ GET_SEQUENCING_GROUPS_BY_COHORT_QUERY = gql(
     query SGByCohortQuery($cohort_id: String!) {
         cohorts(id: {eq: $cohort_id}) {
             name
+            project {
+                dataset
+            }
             sequencingGroups {
                 id
                 meta
@@ -125,10 +128,10 @@ GET_PEDIGREE_QUERY = gql(
 )
 
 
-_metamist: Optional['Metamist'] = None
+_metamist: Optional["Metamist"] = None
 
 
-def get_metamist() -> 'Metamist':
+def get_metamist() -> "Metamist":
     """Return the cohort object"""
     global _metamist
     if not _metamist:
@@ -148,14 +151,14 @@ class AnalysisStatus(Enum):
     https://github.com/populationgenomics/sample-metadata/blob/dev/models/enums/analysis.py#L14-L21
     """
 
-    QUEUED = 'queued'
-    IN_PROGRESS = 'in-progress'
-    FAILED = 'failed'
-    COMPLETED = 'completed'
-    UNKNOWN = 'unknown'
+    QUEUED = "queued"
+    IN_PROGRESS = "in-progress"
+    FAILED = "failed"
+    COMPLETED = "completed"
+    UNKNOWN = "unknown"
 
     @staticmethod
-    def parse(name: str) -> 'AnalysisStatus':
+    def parse(name: str) -> "AnalysisStatus":
         """
         Parse str and create a AnalysisStatus object
         """
@@ -173,24 +176,24 @@ class AnalysisType(Enum):
     the metamist package.
     """
 
-    QC = 'qc'
-    JOINT_CALLING = 'joint-calling'
-    GVCF = 'gvcf'
-    CRAM = 'cram'
-    MITO_CRAM = 'mito-cram'
-    CUSTOM = 'custom'
-    ES_INDEX = 'es-index'
-    COMBINER = 'combiner'
+    QC = "qc"
+    JOINT_CALLING = "joint-calling"
+    GVCF = "gvcf"
+    CRAM = "cram"
+    MITO_CRAM = "mito-cram"
+    CUSTOM = "custom"
+    ES_INDEX = "es-index"
+    COMBINER = "combiner"
 
     @staticmethod
-    def parse(val: str) -> 'AnalysisType':
+    def parse(val: str) -> "AnalysisType":
         """
         Parse str and create a AnalysisStatus object
         """
         d = {v.value: v for v in AnalysisType}
         if val not in d:
             raise MetamistError(
-                f'Unrecognised analysis type {val}. Available: {list(d.keys())}',
+                f"Unrecognised analysis type {val}. Available: {list(d.keys())}",
             )
         return d[val.lower()]
 
@@ -212,28 +215,28 @@ class Analysis:
     meta: dict
 
     @staticmethod
-    def parse(data: dict) -> 'Analysis':
+    def parse(data: dict) -> "Analysis":
         """
         Parse data to create an Analysis object.
         """
-        req_keys = ['id', 'type', 'status']
+        req_keys = ["id", "type", "status"]
         if any(k not in data for k in req_keys):
             for key in req_keys:
                 if key not in data:
                     LOGGER.error(f'"Analysis" data does not have {key}: {data}')
-            raise ValueError(f'Cannot parse metamist Sequence {data}')
+            raise ValueError(f"Cannot parse metamist Sequence {data}")
 
-        output = data.get('output')
+        output = data.get("output")
         if output:
             output = to_path(output)
 
         a = Analysis(
-            id=int(data['id']),
-            type=AnalysisType.parse(data['type']),
-            status=AnalysisStatus.parse(data['status']),
-            sequencing_group_ids=set([s['id'] for s in data['sequencingGroups']]),
+            id=int(data["id"]),
+            type=AnalysisType.parse(data["type"]),
+            status=AnalysisStatus.parse(data["status"]),
+            sequencing_group_ids=set([s["id"] for s in data["sequencingGroups"]]),
             output=output,
-            meta=data.get('meta') or {},
+            meta=data.get("meta") or {},
         )
         return a
 
@@ -244,7 +247,7 @@ class Metamist:
     """
 
     def __init__(self) -> None:
-        self.default_dataset: str = get_config()['workflow']['dataset']
+        self.default_dataset: str = get_config()["workflow"]["dataset"]
         self.aapi = AnalysisApi()
 
     @retry(
@@ -266,7 +269,7 @@ class Metamist:
         except ServiceException:
             # raise here so the retry occurs
             LOGGER.warning(
-                f'Retrying {api_func} ...',
+                f"Retrying {api_func} ...",
             )
             raise
 
@@ -282,7 +285,7 @@ class Metamist:
             # log the error and continue
             traceback.print_exc()
             LOGGER.error(
-                f'Error: {e} Call {api_func} failed with payload:\n{kwargv!s}',
+                f"Error: {e} Call {api_func} failed with payload:\n{kwargv!s}",
             )
         # TODO: discuss should we catch all here as well?
         # except Exception as e:
@@ -302,26 +305,26 @@ class Metamist:
         and filtering options.
         """
         metamist_proj = self.get_metamist_proj(dataset_name)
-        LOGGER.info(f'Getting sequencing groups for dataset {metamist_proj}')
+        LOGGER.info(f"Getting sequencing groups for dataset {metamist_proj}")
 
-        skip_sgs = get_config()['workflow'].get('skip_sgs', [])
-        only_sgs = get_config()['workflow'].get('only_sgs', [])
-        sequencing_type = get_config()['workflow'].get('sequencing_type')
+        skip_sgs = get_config()["workflow"].get("skip_sgs", [])
+        only_sgs = get_config()["workflow"].get("only_sgs", [])
+        sequencing_type = get_config()["workflow"].get("sequencing_type")
 
         if only_sgs and skip_sgs:
-            raise MetamistError('Cannot specify both only_sgs and skip_sgs in config')
+            raise MetamistError("Cannot specify both only_sgs and skip_sgs in config")
 
         sequencing_group_entries = query(
             GET_SEQUENCING_GROUPS_QUERY,
             variables={
-                'metamist_proj': metamist_proj,
-                'only_sgs': only_sgs,
-                'skip_sgs': skip_sgs,
-                'sequencing_type': sequencing_type,
+                "metamist_proj": metamist_proj,
+                "only_sgs": only_sgs,
+                "skip_sgs": skip_sgs,
+                "sequencing_type": sequencing_type,
             },
         )
 
-        return sequencing_group_entries['project']['sequencingGroups']
+        return sequencing_group_entries["project"]["sequencingGroups"]
 
     def update_analysis(self, analysis: Analysis, status: AnalysisStatus):
         """
@@ -355,15 +358,15 @@ class Metamist:
         analyses = query(
             GET_ANALYSES_QUERY,
             variables={
-                'metamist_proj': metamist_proj,
-                'analysis_type': analysis_type.value,
-                'analysis_status': analysis_status.name,
+                "metamist_proj": metamist_proj,
+                "analysis_type": analysis_type.value,
+                "analysis_status": analysis_status.name,
             },
         )
 
         analysis_per_sid: dict[str, Analysis] = dict()
 
-        for analysis in analyses['project']['analyses']:
+        for analysis in analyses["project"]["analyses"]:
             a = Analysis.parse(analysis)
             if not a:
                 continue
@@ -371,14 +374,14 @@ class Metamist:
             assert a.status == analysis_status, analysis
             assert a.type == analysis_type, analysis
             if len(a.sequencing_group_ids) < 1:
-                LOGGER.warning(f'Analysis has no sequencing group ids. {analysis}')
+                LOGGER.warning(f"Analysis has no sequencing group ids. {analysis}")
                 continue
 
             assert len(a.sequencing_group_ids) == 1, analysis
             analysis_per_sid[list(a.sequencing_group_ids)[0]] = a
 
         LOGGER.info(
-            f'Querying {analysis_type} analysis entries for {metamist_proj}: found {len(analysis_per_sid)}',
+            f"Querying {analysis_type} analysis entries for {metamist_proj}: found {len(analysis_per_sid)}",
         )
         return analysis_per_sid
 
@@ -423,11 +426,12 @@ class Metamist:
         )
         if aid is None:
             LOGGER.error(
-                f'Failed to create Analysis(type={type_}, status={status}, output={output!s}) in {metamist_proj}',
+                f"Failed to create Analysis(type={type_}, status={status}, output={output!s}) in {metamist_proj}",
             )
             return None
         LOGGER.info(
-            f'Created Analysis(id={aid}, type={type_}, status={status}, ' f'output={output!s}) in {metamist_proj}',
+            f"Created Analysis(id={aid}, type={type_}, status={status}, "
+            f"output={output!s}) in {metamist_proj}",
         )
         return aid
 
@@ -436,9 +440,9 @@ class Metamist:
         Retrieve PED lines for a specified SM project, with external participant IDs.
         """
         metamist_proj = self.get_metamist_proj(dataset)
-        entries = query(GET_PEDIGREE_QUERY, variables={'metamist_proj': metamist_proj})
+        entries = query(GET_PEDIGREE_QUERY, variables={"metamist_proj": metamist_proj})
 
-        pedigree_entries = entries['project']['pedigree']
+        pedigree_entries = entries["project"]["pedigree"]
 
         return pedigree_entries
 
@@ -447,8 +451,10 @@ class Metamist:
         Return the Metamist project name, appending '-test' if the access level is 'test'.
         """
         metamist_proj = dataset or self.default_dataset
-        if get_config()['workflow']['access_level'] == 'test' and not metamist_proj.endswith('-test'):
-            metamist_proj += '-test'
+        if get_config()["workflow"][
+            "access_level"
+        ] == "test" and not metamist_proj.endswith("-test"):
+            metamist_proj += "-test"
 
         return metamist_proj
 
@@ -474,31 +480,31 @@ class Assay:
         sg_id: str,
         check_existence: bool = False,
         run_parse_reads: bool = True,
-    ) -> 'Assay':
+    ) -> "Assay":
         """
         Create from a dictionary.
         """
 
-        assay_keys = ['id', 'type', 'meta']
+        assay_keys = ["id", "type", "meta"]
         missing_keys = [key for key in assay_keys if data.get(key) is None]
 
         if missing_keys:
             raise ValueError(
-                f'Cannot parse metamist Sequence {data}. Missing keys: {missing_keys}',
+                f"Cannot parse metamist Sequence {data}. Missing keys: {missing_keys}",
             )
 
-        assay_type = str(data['type'])
+        assay_type = str(data["type"])
         assert assay_type, data
         mm_seq = Assay(
-            id=str(data['id']),
+            id=str(data["id"]),
             sequencing_group_id=sg_id,
-            meta=data['meta'],
+            meta=data["meta"],
             assay_type=assay_type,
         )
         if run_parse_reads:
             mm_seq.alignment_input = parse_reads(
                 sequencing_group_id=sg_id,
-                assay_meta=data['meta'],
+                assay_meta=data["meta"],
                 check_existence=check_existence,
             )
         return mm_seq
@@ -508,7 +514,8 @@ def get_cohort_sgs(cohort_id: str) -> dict:
     """
     Retrieve sequencing group entries for a single cohort.
     """
-    entries = query(GET_SEQUENCING_GROUPS_BY_COHORT_QUERY, {'cohort_id': cohort_id})
+    LOGGER.info(f"Getting sequencing groups for cohort {cohort_id}")
+    entries = query(GET_SEQUENCING_GROUPS_BY_COHORT_QUERY, {"cohort_id": cohort_id})
 
     # Create dictionary keying sequencing groups by project and including cohort name
     # {
@@ -517,20 +524,23 @@ def get_cohort_sgs(cohort_id: str) -> dict:
     #         ...
     #     },
     #     "name": "CohortName"
+    #     "dataset": "DatasetName"
     # }
-    if len(entries['cohorts']) != 1:
-        raise MetamistError('We only support one cohort at a time currently')
+    if len(entries["cohorts"]) != 1:
+        raise MetamistError("We only support one cohort at a time currently")
 
-    if entries.get('data') is None and 'errors' in entries:
-        message = entries['errors'][0]['message']
-        raise MetamistError(f'Error fetching cohort: {message}')
+    if entries.get("data") is None and "errors" in entries:
+        message = entries["errors"][0]["message"]
+        raise MetamistError(f"Error fetching cohort: {message}")
 
-    cohort_name = entries['cohorts'][0]['name']
-    sequencing_groups = entries['cohorts'][0]['sequencingGroups']
+    cohort_name = entries["cohorts"][0]["name"]
+    cohort_dataset = entries["cohorts"][0]["project"]["dataset"]
+    sequencing_groups = entries["cohorts"][0]["sequencingGroups"]
 
     return {
-        'name': cohort_name,
-        'sequencing_groups': sequencing_groups,
+        "name": cohort_name,
+        "dataset": cohort_dataset,
+        "sequencing_groups": sequencing_groups,
     }
 
 
@@ -544,9 +554,9 @@ def parse_reads(  # pylint: disable=too-many-return-statements
     `check_existence`: check if fastq/crams exist on buckets.
     Default value is pulled from self.metamist and can be overridden.
     """
-    reads_data = assay_meta.get('reads')
-    reads_type = assay_meta.get('reads_type')
-    reference_assembly = assay_meta.get('reference_assembly', {}).get('location')
+    reads_data = assay_meta.get("reads")
+    reads_type = assay_meta.get("reads_type")
+    reference_assembly = assay_meta.get("reference_assembly", {}).get("location")
 
     if not reads_data:
         raise MetamistError(f'{sequencing_group_id}: no "meta/reads" field in meta')
@@ -554,59 +564,59 @@ def parse_reads(  # pylint: disable=too-many-return-statements
         raise MetamistError(
             f'{sequencing_group_id}: no "meta/reads_type" field in meta',
         )
-    supported_types = ('fastq', 'bam', 'cram')
+    supported_types = ("fastq", "bam", "cram")
     if reads_type not in supported_types:
         raise MetamistError(
             f'{sequencing_group_id}: ERROR: "reads_type" is expected to be one of {supported_types}',
         )
 
-    if reads_type in ('bam', 'cram'):
+    if reads_type in ("bam", "cram"):
         if len(reads_data) > 1:
             raise MetamistError(
-                f'{sequencing_group_id}: supporting only single bam/cram input',
+                f"{sequencing_group_id}: supporting only single bam/cram input",
             )
 
-        location = reads_data[0]['location']
-        if not (location.endswith('.cram') or location.endswith('.bam')):
+        location = reads_data[0]["location"]
+        if not (location.endswith(".cram") or location.endswith(".bam")):
             raise MetamistError(
-                f'{sequencing_group_id}: ERROR: expected the file to have an extension '
-                f'.cram or .bam, got: {location}',
+                f"{sequencing_group_id}: ERROR: expected the file to have an extension "
+                f".cram or .bam, got: {location}",
             )
-        if get_config()['workflow']['access_level'] == 'test':
-            location = location.replace('-main-upload/', '-test-upload/')
+        if get_config()["workflow"]["access_level"] == "test":
+            location = location.replace("-main-upload/", "-test-upload/")
         if check_existence and not exists(location):
             raise MetamistError(
-                f'{sequencing_group_id}: ERROR: index file does not exist: {location}',
+                f"{sequencing_group_id}: ERROR: index file does not exist: {location}",
             )
 
         # Index:
         index_location = None
-        if reads_data[0].get('secondaryFiles'):
-            index_location = reads_data[0]['secondaryFiles'][0]['location']
-            if (location.endswith('.cram') and not index_location.endswith('.crai')) or (
-                location.endswith('.bam') and not index_location.endswith('.bai')
-            ):
+        if reads_data[0].get("secondaryFiles"):
+            index_location = reads_data[0]["secondaryFiles"][0]["location"]
+            if (
+                location.endswith(".cram") and not index_location.endswith(".crai")
+            ) or (location.endswith(".bam") and not index_location.endswith(".bai")):
                 raise MetamistError(
-                    f'{sequencing_group_id}: ERROR: expected the index file to have an extension '
-                    f'.crai or .bai, got: {index_location}',
+                    f"{sequencing_group_id}: ERROR: expected the index file to have an extension "
+                    f".crai or .bai, got: {index_location}",
                 )
-            if get_config()['workflow']['access_level'] == 'test':
+            if get_config()["workflow"]["access_level"] == "test":
                 index_location = index_location.replace(
-                    '-main-upload/',
-                    '-test-upload/',
+                    "-main-upload/",
+                    "-test-upload/",
                 )
             if check_existence and not exists(index_location):
                 raise MetamistError(
-                    f'{sequencing_group_id}: ERROR: index file does not exist: {index_location}',
+                    f"{sequencing_group_id}: ERROR: index file does not exist: {index_location}",
                 )
 
-        if location.endswith('.cram'):
+        if location.endswith(".cram"):
             return CramPath(
                 location,
                 index_path=index_location,
                 reference_assembly=reference_assembly,
             )
-        assert location.endswith('.bam')
+        assert location.endswith(".bam")
         return BamPath(location, index_path=index_location)
 
     fastq_pairs = FastqPairs()
@@ -614,24 +624,24 @@ def parse_reads(  # pylint: disable=too-many-return-statements
     for lane_pair in reads_data:
         if len(lane_pair) != 2:
             raise ValueError(
-                f'Sequence data for sequencing group {sequencing_group_id} is incorrectly '
-                f'formatted. Expecting 2 entries per lane (R1 and R2 fastqs), '
-                f'but got {len(lane_pair)}. '
-                f'Read data: {pprint.pformat(lane_pair)}',
+                f"Sequence data for sequencing group {sequencing_group_id} is incorrectly "
+                f"formatted. Expecting 2 entries per lane (R1 and R2 fastqs), "
+                f"but got {len(lane_pair)}. "
+                f"Read data: {pprint.pformat(lane_pair)}",
             )
-        if check_existence and not exists(lane_pair[0]['location']):
+        if check_existence and not exists(lane_pair[0]["location"]):
             raise MetamistError(
-                f'{sequencing_group_id}: ERROR: read 1 file does not exist: {lane_pair[0]["location"]}',
+                f"{sequencing_group_id}: ERROR: read 1 file does not exist: {lane_pair[0]['location']}",
             )
-        if check_existence and not exists(lane_pair[1]['location']):
+        if check_existence and not exists(lane_pair[1]["location"]):
             raise MetamistError(
-                f'{sequencing_group_id}: ERROR: read 2 file does not exist: {lane_pair[1]["location"]}',
+                f"{sequencing_group_id}: ERROR: read 2 file does not exist: {lane_pair[1]['location']}",
             )
 
         fastq_pairs.append(
             FastqPair(
-                to_path(lane_pair[0]['location']),
-                to_path(lane_pair[1]['location']),
+                to_path(lane_pair[0]["location"]),
+                to_path(lane_pair[1]["location"]),
             ),
         )
 

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -128,10 +128,10 @@ GET_PEDIGREE_QUERY = gql(
 )
 
 
-_metamist: Optional["Metamist"] = None
+_metamist: Optional['Metamist'] = None
 
 
-def get_metamist() -> "Metamist":
+def get_metamist() -> 'Metamist':
     """Return the cohort object"""
     global _metamist
     if not _metamist:
@@ -151,14 +151,14 @@ class AnalysisStatus(Enum):
     https://github.com/populationgenomics/sample-metadata/blob/dev/models/enums/analysis.py#L14-L21
     """
 
-    QUEUED = "queued"
-    IN_PROGRESS = "in-progress"
-    FAILED = "failed"
-    COMPLETED = "completed"
-    UNKNOWN = "unknown"
+    QUEUED = 'queued'
+    IN_PROGRESS = 'in-progress'
+    FAILED = 'failed'
+    COMPLETED = 'completed'
+    UNKNOWN = 'unknown'
 
     @staticmethod
-    def parse(name: str) -> "AnalysisStatus":
+    def parse(name: str) -> 'AnalysisStatus':
         """
         Parse str and create a AnalysisStatus object
         """
@@ -176,24 +176,24 @@ class AnalysisType(Enum):
     the metamist package.
     """
 
-    QC = "qc"
-    JOINT_CALLING = "joint-calling"
-    GVCF = "gvcf"
-    CRAM = "cram"
-    MITO_CRAM = "mito-cram"
-    CUSTOM = "custom"
-    ES_INDEX = "es-index"
-    COMBINER = "combiner"
+    QC = 'qc'
+    JOINT_CALLING = 'joint-calling'
+    GVCF = 'gvcf'
+    CRAM = 'cram'
+    MITO_CRAM = 'mito-cram'
+    CUSTOM = 'custom'
+    ES_INDEX = 'es-index'
+    COMBINER = 'combiner'
 
     @staticmethod
-    def parse(val: str) -> "AnalysisType":
+    def parse(val: str) -> 'AnalysisType':
         """
         Parse str and create a AnalysisStatus object
         """
         d = {v.value: v for v in AnalysisType}
         if val not in d:
             raise MetamistError(
-                f"Unrecognised analysis type {val}. Available: {list(d.keys())}",
+                f'Unrecognised analysis type {val}. Available: {list(d.keys())}',
             )
         return d[val.lower()]
 
@@ -215,28 +215,28 @@ class Analysis:
     meta: dict
 
     @staticmethod
-    def parse(data: dict) -> "Analysis":
+    def parse(data: dict) -> 'Analysis':
         """
         Parse data to create an Analysis object.
         """
-        req_keys = ["id", "type", "status"]
+        req_keys = ['id', 'type', 'status']
         if any(k not in data for k in req_keys):
             for key in req_keys:
                 if key not in data:
                     LOGGER.error(f'"Analysis" data does not have {key}: {data}')
-            raise ValueError(f"Cannot parse metamist Sequence {data}")
+            raise ValueError(f'Cannot parse metamist Sequence {data}')
 
-        output = data.get("output")
+        output = data.get('output')
         if output:
             output = to_path(output)
 
         a = Analysis(
-            id=int(data["id"]),
-            type=AnalysisType.parse(data["type"]),
-            status=AnalysisStatus.parse(data["status"]),
-            sequencing_group_ids=set([s["id"] for s in data["sequencingGroups"]]),
+            id=int(data['id']),
+            type=AnalysisType.parse(data['type']),
+            status=AnalysisStatus.parse(data['status']),
+            sequencing_group_ids=set([s['id'] for s in data['sequencingGroups']]),
             output=output,
-            meta=data.get("meta") or {},
+            meta=data.get('meta') or {},
         )
         return a
 
@@ -247,7 +247,7 @@ class Metamist:
     """
 
     def __init__(self) -> None:
-        self.default_dataset: str = get_config()["workflow"]["dataset"]
+        self.default_dataset: str = get_config()['workflow']['dataset']
         self.aapi = AnalysisApi()
 
     @retry(
@@ -269,7 +269,7 @@ class Metamist:
         except ServiceException:
             # raise here so the retry occurs
             LOGGER.warning(
-                f"Retrying {api_func} ...",
+                f'Retrying {api_func} ...',
             )
             raise
 
@@ -285,7 +285,7 @@ class Metamist:
             # log the error and continue
             traceback.print_exc()
             LOGGER.error(
-                f"Error: {e} Call {api_func} failed with payload:\n{kwargv!s}",
+                f'Error: {e} Call {api_func} failed with payload:\n{kwargv!s}',
             )
         # TODO: discuss should we catch all here as well?
         # except Exception as e:
@@ -305,26 +305,26 @@ class Metamist:
         and filtering options.
         """
         metamist_proj = self.get_metamist_proj(dataset_name)
-        LOGGER.info(f"Getting sequencing groups for dataset {metamist_proj}")
+        LOGGER.info(f'Getting sequencing groups for dataset {metamist_proj}')
 
-        skip_sgs = get_config()["workflow"].get("skip_sgs", [])
-        only_sgs = get_config()["workflow"].get("only_sgs", [])
-        sequencing_type = get_config()["workflow"].get("sequencing_type")
+        skip_sgs = get_config()['workflow'].get('skip_sgs', [])
+        only_sgs = get_config()['workflow'].get('only_sgs', [])
+        sequencing_type = get_config()['workflow'].get('sequencing_type')
 
         if only_sgs and skip_sgs:
-            raise MetamistError("Cannot specify both only_sgs and skip_sgs in config")
+            raise MetamistError('Cannot specify both only_sgs and skip_sgs in config')
 
         sequencing_group_entries = query(
             GET_SEQUENCING_GROUPS_QUERY,
             variables={
-                "metamist_proj": metamist_proj,
-                "only_sgs": only_sgs,
-                "skip_sgs": skip_sgs,
-                "sequencing_type": sequencing_type,
+                'metamist_proj': metamist_proj,
+                'only_sgs': only_sgs,
+                'skip_sgs': skip_sgs,
+                'sequencing_type': sequencing_type,
             },
         )
 
-        return sequencing_group_entries["project"]["sequencingGroups"]
+        return sequencing_group_entries['project']['sequencingGroups']
 
     def update_analysis(self, analysis: Analysis, status: AnalysisStatus):
         """
@@ -358,15 +358,15 @@ class Metamist:
         analyses = query(
             GET_ANALYSES_QUERY,
             variables={
-                "metamist_proj": metamist_proj,
-                "analysis_type": analysis_type.value,
-                "analysis_status": analysis_status.name,
+                'metamist_proj': metamist_proj,
+                'analysis_type': analysis_type.value,
+                'analysis_status': analysis_status.name,
             },
         )
 
         analysis_per_sid: dict[str, Analysis] = dict()
 
-        for analysis in analyses["project"]["analyses"]:
+        for analysis in analyses['project']['analyses']:
             a = Analysis.parse(analysis)
             if not a:
                 continue
@@ -374,14 +374,14 @@ class Metamist:
             assert a.status == analysis_status, analysis
             assert a.type == analysis_type, analysis
             if len(a.sequencing_group_ids) < 1:
-                LOGGER.warning(f"Analysis has no sequencing group ids. {analysis}")
+                LOGGER.warning(f'Analysis has no sequencing group ids. {analysis}')
                 continue
 
             assert len(a.sequencing_group_ids) == 1, analysis
             analysis_per_sid[list(a.sequencing_group_ids)[0]] = a
 
         LOGGER.info(
-            f"Querying {analysis_type} analysis entries for {metamist_proj}: found {len(analysis_per_sid)}",
+            f'Querying {analysis_type} analysis entries for {metamist_proj}: found {len(analysis_per_sid)}',
         )
         return analysis_per_sid
 
@@ -426,12 +426,11 @@ class Metamist:
         )
         if aid is None:
             LOGGER.error(
-                f"Failed to create Analysis(type={type_}, status={status}, output={output!s}) in {metamist_proj}",
+                f'Failed to create Analysis(type={type_}, status={status}, output={output!s}) in {metamist_proj}',
             )
             return None
         LOGGER.info(
-            f"Created Analysis(id={aid}, type={type_}, status={status}, "
-            f"output={output!s}) in {metamist_proj}",
+            f'Created Analysis(id={aid}, type={type_}, status={status}, output={output!s}) in {metamist_proj}',
         )
         return aid
 
@@ -440,9 +439,9 @@ class Metamist:
         Retrieve PED lines for a specified SM project, with external participant IDs.
         """
         metamist_proj = self.get_metamist_proj(dataset)
-        entries = query(GET_PEDIGREE_QUERY, variables={"metamist_proj": metamist_proj})
+        entries = query(GET_PEDIGREE_QUERY, variables={'metamist_proj': metamist_proj})
 
-        pedigree_entries = entries["project"]["pedigree"]
+        pedigree_entries = entries['project']['pedigree']
 
         return pedigree_entries
 
@@ -451,10 +450,8 @@ class Metamist:
         Return the Metamist project name, appending '-test' if the access level is 'test'.
         """
         metamist_proj = dataset or self.default_dataset
-        if get_config()["workflow"][
-            "access_level"
-        ] == "test" and not metamist_proj.endswith("-test"):
-            metamist_proj += "-test"
+        if get_config()['workflow']['access_level'] == 'test' and not metamist_proj.endswith('-test'):
+            metamist_proj += '-test'
 
         return metamist_proj
 
@@ -480,31 +477,31 @@ class Assay:
         sg_id: str,
         check_existence: bool = False,
         run_parse_reads: bool = True,
-    ) -> "Assay":
+    ) -> 'Assay':
         """
         Create from a dictionary.
         """
 
-        assay_keys = ["id", "type", "meta"]
+        assay_keys = ['id', 'type', 'meta']
         missing_keys = [key for key in assay_keys if data.get(key) is None]
 
         if missing_keys:
             raise ValueError(
-                f"Cannot parse metamist Sequence {data}. Missing keys: {missing_keys}",
+                f'Cannot parse metamist Sequence {data}. Missing keys: {missing_keys}',
             )
 
-        assay_type = str(data["type"])
+        assay_type = str(data['type'])
         assert assay_type, data
         mm_seq = Assay(
-            id=str(data["id"]),
+            id=str(data['id']),
             sequencing_group_id=sg_id,
-            meta=data["meta"],
+            meta=data['meta'],
             assay_type=assay_type,
         )
         if run_parse_reads:
             mm_seq.alignment_input = parse_reads(
                 sequencing_group_id=sg_id,
-                assay_meta=data["meta"],
+                assay_meta=data['meta'],
                 check_existence=check_existence,
             )
         return mm_seq
@@ -514,8 +511,8 @@ def get_cohort_sgs(cohort_id: str) -> dict:
     """
     Retrieve sequencing group entries for a single cohort.
     """
-    LOGGER.info(f"Getting sequencing groups for cohort {cohort_id}")
-    entries = query(GET_SEQUENCING_GROUPS_BY_COHORT_QUERY, {"cohort_id": cohort_id})
+    LOGGER.info(f'Getting sequencing groups for cohort {cohort_id}')
+    entries = query(GET_SEQUENCING_GROUPS_BY_COHORT_QUERY, {'cohort_id': cohort_id})
 
     # Create dictionary keying sequencing groups by project and including cohort name
     # {
@@ -526,21 +523,21 @@ def get_cohort_sgs(cohort_id: str) -> dict:
     #     "name": "CohortName"
     #     "dataset": "DatasetName"
     # }
-    if len(entries["cohorts"]) != 1:
-        raise MetamistError("We only support one cohort at a time currently")
+    if len(entries['cohorts']) != 1:
+        raise MetamistError('We only support one cohort at a time currently')
 
-    if entries.get("data") is None and "errors" in entries:
-        message = entries["errors"][0]["message"]
-        raise MetamistError(f"Error fetching cohort: {message}")
+    if entries.get('data') is None and 'errors' in entries:
+        message = entries['errors'][0]['message']
+        raise MetamistError(f'Error fetching cohort: {message}')
 
-    cohort_name = entries["cohorts"][0]["name"]
-    cohort_dataset = entries["cohorts"][0]["project"]["dataset"]
-    sequencing_groups = entries["cohorts"][0]["sequencingGroups"]
+    cohort_name = entries['cohorts'][0]['name']
+    cohort_dataset = entries['cohorts'][0]['project']['dataset']
+    sequencing_groups = entries['cohorts'][0]['sequencingGroups']
 
     return {
-        "name": cohort_name,
-        "dataset": cohort_dataset,
-        "sequencing_groups": sequencing_groups,
+        'name': cohort_name,
+        'dataset': cohort_dataset,
+        'sequencing_groups': sequencing_groups,
     }
 
 
@@ -554,9 +551,9 @@ def parse_reads(  # pylint: disable=too-many-return-statements
     `check_existence`: check if fastq/crams exist on buckets.
     Default value is pulled from self.metamist and can be overridden.
     """
-    reads_data = assay_meta.get("reads")
-    reads_type = assay_meta.get("reads_type")
-    reference_assembly = assay_meta.get("reference_assembly", {}).get("location")
+    reads_data = assay_meta.get('reads')
+    reads_type = assay_meta.get('reads_type')
+    reference_assembly = assay_meta.get('reference_assembly', {}).get('location')
 
     if not reads_data:
         raise MetamistError(f'{sequencing_group_id}: no "meta/reads" field in meta')
@@ -564,59 +561,58 @@ def parse_reads(  # pylint: disable=too-many-return-statements
         raise MetamistError(
             f'{sequencing_group_id}: no "meta/reads_type" field in meta',
         )
-    supported_types = ("fastq", "bam", "cram")
+    supported_types = ('fastq', 'bam', 'cram')
     if reads_type not in supported_types:
         raise MetamistError(
             f'{sequencing_group_id}: ERROR: "reads_type" is expected to be one of {supported_types}',
         )
 
-    if reads_type in ("bam", "cram"):
+    if reads_type in ('bam', 'cram'):
         if len(reads_data) > 1:
             raise MetamistError(
-                f"{sequencing_group_id}: supporting only single bam/cram input",
+                f'{sequencing_group_id}: supporting only single bam/cram input',
             )
 
-        location = reads_data[0]["location"]
-        if not (location.endswith(".cram") or location.endswith(".bam")):
+        location = reads_data[0]['location']
+        if not (location.endswith('.cram') or location.endswith('.bam')):
             raise MetamistError(
-                f"{sequencing_group_id}: ERROR: expected the file to have an extension "
-                f".cram or .bam, got: {location}",
+                f'{sequencing_group_id}: ERROR: expected the file to have an extension .cram or .bam, got: {location}',
             )
-        if get_config()["workflow"]["access_level"] == "test":
-            location = location.replace("-main-upload/", "-test-upload/")
+        if get_config()['workflow']['access_level'] == 'test':
+            location = location.replace('-main-upload/', '-test-upload/')
         if check_existence and not exists(location):
             raise MetamistError(
-                f"{sequencing_group_id}: ERROR: index file does not exist: {location}",
+                f'{sequencing_group_id}: ERROR: index file does not exist: {location}',
             )
 
         # Index:
         index_location = None
-        if reads_data[0].get("secondaryFiles"):
-            index_location = reads_data[0]["secondaryFiles"][0]["location"]
-            if (
-                location.endswith(".cram") and not index_location.endswith(".crai")
-            ) or (location.endswith(".bam") and not index_location.endswith(".bai")):
+        if reads_data[0].get('secondaryFiles'):
+            index_location = reads_data[0]['secondaryFiles'][0]['location']
+            if (location.endswith('.cram') and not index_location.endswith('.crai')) or (
+                location.endswith('.bam') and not index_location.endswith('.bai')
+            ):
                 raise MetamistError(
-                    f"{sequencing_group_id}: ERROR: expected the index file to have an extension "
-                    f".crai or .bai, got: {index_location}",
+                    f'{sequencing_group_id}: ERROR: expected the index file to have an extension '
+                    f'.crai or .bai, got: {index_location}',
                 )
-            if get_config()["workflow"]["access_level"] == "test":
+            if get_config()['workflow']['access_level'] == 'test':
                 index_location = index_location.replace(
-                    "-main-upload/",
-                    "-test-upload/",
+                    '-main-upload/',
+                    '-test-upload/',
                 )
             if check_existence and not exists(index_location):
                 raise MetamistError(
-                    f"{sequencing_group_id}: ERROR: index file does not exist: {index_location}",
+                    f'{sequencing_group_id}: ERROR: index file does not exist: {index_location}',
                 )
 
-        if location.endswith(".cram"):
+        if location.endswith('.cram'):
             return CramPath(
                 location,
                 index_path=index_location,
                 reference_assembly=reference_assembly,
             )
-        assert location.endswith(".bam")
+        assert location.endswith('.bam')
         return BamPath(location, index_path=index_location)
 
     fastq_pairs = FastqPairs()
@@ -624,24 +620,24 @@ def parse_reads(  # pylint: disable=too-many-return-statements
     for lane_pair in reads_data:
         if len(lane_pair) != 2:
             raise ValueError(
-                f"Sequence data for sequencing group {sequencing_group_id} is incorrectly "
-                f"formatted. Expecting 2 entries per lane (R1 and R2 fastqs), "
-                f"but got {len(lane_pair)}. "
-                f"Read data: {pprint.pformat(lane_pair)}",
+                f'Sequence data for sequencing group {sequencing_group_id} is incorrectly '
+                f'formatted. Expecting 2 entries per lane (R1 and R2 fastqs), '
+                f'but got {len(lane_pair)}. '
+                f'Read data: {pprint.pformat(lane_pair)}',
             )
-        if check_existence and not exists(lane_pair[0]["location"]):
+        if check_existence and not exists(lane_pair[0]['location']):
             raise MetamistError(
-                f"{sequencing_group_id}: ERROR: read 1 file does not exist: {lane_pair[0]['location']}",
+                f'{sequencing_group_id}: ERROR: read 1 file does not exist: {lane_pair[0]["location"]}',
             )
-        if check_existence and not exists(lane_pair[1]["location"]):
+        if check_existence and not exists(lane_pair[1]['location']):
             raise MetamistError(
-                f"{sequencing_group_id}: ERROR: read 2 file does not exist: {lane_pair[1]['location']}",
+                f'{sequencing_group_id}: ERROR: read 2 file does not exist: {lane_pair[1]["location"]}',
             )
 
         fastq_pairs.append(
             FastqPair(
-                to_path(lane_pair[0]["location"]),
-                to_path(lane_pair[1]["location"]),
+                to_path(lane_pair[0]['location']),
+                to_path(lane_pair[1]['location']),
             ),
         )
 

--- a/src/cpg_flow/stage.py
+++ b/src/cpg_flow/stage.py
@@ -102,7 +102,7 @@ class StageOutput:
                 raise ValueError(
                     f'{self.stage}: {self.data} is not a dictionary, can\'t get "{key}"',
                 )
-            res = cast(dict, self.data)[key]
+            res = cast('dict', self.data)[key]
         else:
             res = self.data
         return res
@@ -121,7 +121,6 @@ class StageOutput:
         if not isinstance(res, (os.PathLike | str)):
             raise ValueError(f'{res} is not a str or valid Pathlike, will not convert.')
         return str(res)
-
 
     def as_path(self, key=None) -> Path:
         """

--- a/src/cpg_flow/stage.py
+++ b/src/cpg_flow/stage.py
@@ -554,11 +554,11 @@ class Stage(Generic[TargetT], ABC):
                 analysis_outputs.append(outputs.data)
 
             project_name = None
-            if isinstance(target, SequencingGroup):
+            if isinstance(target, SequencingGroup | Cohort):
                 project_name = target.dataset.name
             elif isinstance(target, Dataset):
                 project_name = target.name
-            elif isinstance(target, Cohort | MultiCohort):
+            elif isinstance(target, MultiCohort):
                 project_name = target.analysis_dataset.name
 
             assert isinstance(project_name, str)

--- a/src/cpg_flow/targets/cohort.py
+++ b/src/cpg_flow/targets/cohort.py
@@ -46,12 +46,12 @@ class Cohort(Target):
         self.name = name or get_config()['workflow']['dataset']
 
         # This is the analysis_dataset specified in the workflow config
-        self.analysis_dataset = Dataset(name=get_config()['workflow']['dataset'])
+        analysis_dataset = Dataset(name=get_config()['workflow']['dataset'])
 
         # This value should be populated by the cohort_dataset parameter
         # which represents the dataset that the cohort is associated with
         # If no cohort dataset is provided it will default to the analysis dataset
-        self.dataset = Dataset(name=dataset) if dataset else self.analysis_dataset
+        self.dataset = Dataset(name=dataset) if dataset else analysis_dataset
 
         self._sequencing_group_by_id: dict[str, SequencingGroup] = {}
 

--- a/src/cpg_flow/targets/cohort.py
+++ b/src/cpg_flow/targets/cohort.py
@@ -40,11 +40,19 @@ class Cohort(Target):
     cohort.
     """
 
-    def __init__(self, id: str | None = None, name: str | None = None) -> None:
+    def __init__(self, id: str | None = None, name: str | None = None, dataset: str | None = None) -> None:
         super().__init__()
         self.id = id or get_config()['workflow']['dataset']
         self.name = name or get_config()['workflow']['dataset']
+
+        # This is the analysis_dataset specified in the workflow config
         self.analysis_dataset = Dataset(name=get_config()['workflow']['dataset'])
+
+        # This value should be populated by the cohort_dataset parameter
+        # which represents the dataset that the cohort is associated with
+        # If no cohort dataset is provided it will default to the analysis dataset
+        self.dataset = Dataset(name=dataset) if dataset else self.analysis_dataset
+
         self._sequencing_group_by_id: dict[str, SequencingGroup] = {}
 
     def __repr__(self):

--- a/src/cpg_flow/targets/helpers.py
+++ b/src/cpg_flow/targets/helpers.py
@@ -13,5 +13,5 @@ def seq_type_subdir() -> str:
     """
     Subdirectory parametrised by sequencing type. For genomes, we don't prefix at all.
     """
-    seq_type = get_config()["workflow"].get("sequencing_type")
-    return "" if not seq_type or seq_type == "genome" else seq_type
+    seq_type = get_config()['workflow'].get('sequencing_type')
+    return '' if not seq_type or seq_type == 'genome' else seq_type

--- a/src/cpg_flow/targets/multicohort.py
+++ b/src/cpg_flow/targets/multicohort.py
@@ -137,7 +137,7 @@ class MultiCohort(Target):
                 all_sequencing_groups[sg.id] = sg
         return list(all_sequencing_groups.values())
 
-    def create_cohort(self, id: str, name: str) -> 'Cohort':
+    def create_cohort(self, id: str, name: str, dataset: str | None) -> 'Cohort':
         """
         Create a cohort and add it to the multi-cohort.
         """
@@ -145,7 +145,7 @@ class MultiCohort(Target):
             LOGGER.debug(f'Cohort {id} already exists in the multi-cohort')
             return self._cohorts_by_id[id]
 
-        c = Cohort(id=id, name=name)
+        c = Cohort(id=id, name=name, dataset=dataset)
         self._cohorts_by_id[c.id] = c
         return c
 

--- a/src/cpg_flow/targets/multicohort.py
+++ b/src/cpg_flow/targets/multicohort.py
@@ -137,7 +137,7 @@ class MultiCohort(Target):
                 all_sequencing_groups[sg.id] = sg
         return list(all_sequencing_groups.values())
 
-    def create_cohort(self, id: str, name: str, dataset: str | None) -> 'Cohort':
+    def create_cohort(self, id: str, name: str, dataset: str | None = None) -> 'Cohort':
         """
         Create a cohort and add it to the multi-cohort.
         """

--- a/src/cpg_flow/utils.py
+++ b/src/cpg_flow/utils.py
@@ -196,7 +196,7 @@ def exists_not_cached(path: Path | str, verbose: bool = True) -> bool:
     @param verbose: print on each check
     @return: True if the object exists
     """
-    path = cast(Path, to_path(path))
+    path = cast('Path', to_path(path))
 
     if path.suffix in ['.mt', '.ht']:
         path /= '_SUCCESS'
@@ -365,7 +365,7 @@ def get_intervals_from_bed(intervals_path: Path) -> list[str]:
         intervals = []
         for line in f:
             chrom, start, end = line.strip().split('\t')
-            intervals.append(f'{chrom}:{int(start)+1}-{end}')
+            intervals.append(f'{chrom}:{int(start) + 1}-{end}')
     return intervals
 
 

--- a/src/cpg_flow/workflow.py
+++ b/src/cpg_flow/workflow.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Optional, Union
 
 import networkx as nx
 import plotly.io as pio
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from cpg_flow.inputs import get_multicohort
 from cpg_flow.show_workflow.graph import GraphPlot
@@ -297,7 +297,7 @@ class Workflow:
                 if _s_name.lower() not in lower_names:
                     raise WorkflowError(
                         f'Value in workflow/{param} "{_s_name}" must be a stage name '
-                        f"or a subset of stages from the available list: "
+                        f'or a subset of stages from the available list: '
                         f'{", ".join(stage_names)}',
                     )
 
@@ -372,7 +372,7 @@ class Workflow:
             if s_name.lower() not in lower_names:
                 raise WorkflowError(
                     f'Value in workflow/only_stages "{s_name}" must be a stage '
-                    f"name or a subset of stages from the available list: "
+                    f'name or a subset of stages from the available list: '
                     f'{", ".join(stage_names)}',
                 )
 
@@ -569,7 +569,7 @@ class Workflow:
 
                     LOGGER.info(f'Workflow graph saved to {html_path}')
 
-            except ConnectionError as e:
+            except RequestsConnectionError as e:
                 LOGGER.error(f'Failed to save workflow graph: {e}')
 
     @staticmethod

--- a/tests/assets/test_cohort/COH1.json
+++ b/tests/assets/test_cohort/COH1.json
@@ -1,5 +1,8 @@
 {
     "name": "Cohort #1",
+    "project": {
+        "dataset": "Cohort #1 Dataset"
+    },
     "sequencing_groups": [
         {
             "id": "CPGLCL17",

--- a/tests/assets/test_cohort/COH2.json
+++ b/tests/assets/test_cohort/COH2.json
@@ -1,5 +1,8 @@
 {
     "name": "Cohort #2",
+    "project": {
+        "dataset": "Cohort #2 Dataset"
+    },
     "sequencing_groups": [
         {
             "id": "CPGLCL17",

--- a/tests/assets/test_cohort/COH3.json
+++ b/tests/assets/test_cohort/COH3.json
@@ -1,5 +1,8 @@
 {
     "name": "Cohort #3",
+    "project": {
+        "dataset": "Cohort #3 Dataset"
+    },
     "sequencing_groups": [
         {
             "id": "CPGccc",

--- a/tests/assets/test_cohort/COH4.json
+++ b/tests/assets/test_cohort/COH4.json
@@ -1,5 +1,8 @@
 {
     "name": "Cohort #4",
+    "project": {
+        "dataset": "Cohort #4 Dataset"
+    },
     "sequencing_groups": [
         {
             "id": "CPGccc",

--- a/tests/assets/test_cohort/COH5.json
+++ b/tests/assets/test_cohort/COH5.json
@@ -1,5 +1,8 @@
 {
     "name": "Cohort #5",
+    "project": {
+        "dataset": "Cohort #5 Dataset"
+    },
     "sequencing_groups": [
         {
             "id": "CPGXXXX",

--- a/tests/stages/__init__.py
+++ b/tests/stages/__init__.py
@@ -36,7 +36,7 @@ def add_sg(ds, id, external_id: str) -> SequencingGroup:
 
 def mock_cohort() -> MultiCohort:
     m = MultiCohort()
-    c = m.create_cohort(id='COH123', name='fewgenomes')
+    c = m.create_cohort(id='COH123', name='fewgenomes', dataset='fewgenomes')
     d = m.create_dataset('my_dataset')
 
     sg1 = add_sg(d, 'CPGAA', external_id='SAMPLE1')
@@ -46,7 +46,7 @@ def mock_cohort() -> MultiCohort:
 
 def mock_multidataset_cohort() -> MultiCohort:
     m = MultiCohort()
-    c = m.create_cohort(id='COH123', name='fewgenomes')
+    c = m.create_cohort(id='COH123', name='fewgenomes', dataset='fewgenomes')
 
     ds = m.create_dataset('my_dataset')
 
@@ -70,7 +70,7 @@ def mock_multicohort() -> MultiCohort:
     mc = MultiCohort()
 
     # Create a cohort with two datasets
-    cohort_a = mc.create_cohort(id='COH111', name='CohortA')
+    cohort_a = mc.create_cohort(id='COH111', name='CohortA', dataset='projecta')
     # Create a dataset in the cohort (legacy)
     ds = mc.create_dataset('projecta')
 
@@ -84,7 +84,7 @@ def mock_multicohort() -> MultiCohort:
     cohort_a.add_sequencing_group_object(add_sg(ds2, 'CPGDDDD', external_id='SAMPLE4'))
 
     # second cohort, third dataset
-    cohort_b = mc.create_cohort(id='COH222', name='CohortB')
+    cohort_b = mc.create_cohort(id='COH222', name='CohortB', dataset='projectb')
     ds3 = mc.create_dataset('projectb')
     cohort_b.add_sequencing_group_object(add_sg(ds3, 'CPGEEEEEE', external_id='SAMPLE5'))
     cohort_b.add_sequencing_group_object(add_sg(ds3, 'CPGFFFFFF', external_id='SAMPLE6'))

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -406,9 +406,7 @@ def test_custom_cohort(mocker: MockFixture, tmp_path, monkeypatch):
     def mock_query(query, variables):
         # Mocking the return value of the query function
         data = mock_get_cohort_sgs('COH5')
-        return {'cohorts': [{'name': data.get('name'), 'sequencingGroups': data.get('sequencing_groups')}]}
-
-    # Patching the query function to mock the GraphQL query
+        return {'cohorts': [{'name': data.get('name'), 'project': {'dataset': data.get('dataset')}, 'sequencingGroups': data.get('sequencing_groups')}]}
     monkeypatch.setattr('cpg_flow.metamist.query', mock_query)
 
     from cpg_flow.inputs import get_multicohort

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -406,7 +406,16 @@ def test_custom_cohort(mocker: MockFixture, tmp_path, monkeypatch):
     def mock_query(query, variables):
         # Mocking the return value of the query function
         data = mock_get_cohort_sgs('COH5')
-        return {'cohorts': [{'name': data.get('name'), 'project': {'dataset': data.get('dataset')}, 'sequencingGroups': data.get('sequencing_groups')}]}
+        return {
+            'cohorts': [
+                {
+                    'name': data.get('name'),
+                    'project': {'dataset': data.get('dataset')},
+                    'sequencingGroups': data.get('sequencing_groups'),
+                },
+            ],
+        }
+
     monkeypatch.setattr('cpg_flow.metamist.query', mock_query)
 
     from cpg_flow.inputs import get_multicohort


### PR DESCRIPTION
This PR will solve the raised issue #75 where the Cohort target currently does not have access to its own dataset (as an attribute) in order to save output files. The proposed solution is as follows.

We keep the analysis_dataset property available in order to maintain the current functionality of existing pipelines.

This also means in future this gives the power to the Pipeline Developers to choose the most appropriate place to save the outputs:

* In the analysis_dataset as defined in the config provided to the analysis_runner (the same one as used in the MultiCohortStage)

* The dataset as pulled from the metadata in Metamist to save each respective Cohorts results in its respective dataset location.

This naming convention is also consistent with say SequencingGroups which don't have an analysis_dataset attribute only a dataset attribute which is determined entirely by metadata on that individual sequencing group (pulled from metamist).

We could discuss whether it would be a helpful feature for all Target types to have access to this analysis_dataset property or not. That would come down to whether it's needed, or useful or would just cause confusion.

SET-490, Resolves #75