### PR TITLE
Set 339 replace use of coloredlogs v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Name: cpg-flow
 Version: 0.1.2
 Location: /Users/whoami/cpg-flow/.venv/lib/python3.10/site-packages
 Editable project location: /Users/whoami/cpg-flow
-Requires: coloredlogs, cpg-utils, grpcio, grpcio-status, hail, ipywidgets, metamist, networkx, plotly, pre-commit, pyyaml
+Requires: cpg-utils, grpcio, grpcio-status, hail, loguru, ipywidgets, metamist, networkx, plotly, pre-commit, pyyaml
 Required-by:
 ```
 
@@ -135,7 +135,7 @@ The build version (static until you rebuild) will look like the following.
 Name: cpg-flow
 Version: 0.1.2
 Location: /Users/whoami/cpg-flow/.venv/lib/python3.10/site-packages
-Requires: coloredlogs, cpg-utils, grpcio, grpcio-status, hail, ipywidgets, metamist, networkx, plotly, pre-commit, pyyaml
+Requires: cpg-utils, grpcio, grpcio-status, hail, ipywidgets, loguru, metamist, networkx, plotly, pre-commit, pyyaml
 Required-by:
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
     "grpcio>=1.53.0",
     # Avoid dependency resolution backtracking, Python 3.10 compatibility
     "grpcio-status>=1.48,<1.50",
+    "loguru>0.7.0",
     "metamist>=6.9.0",
     "networkx>=3.4.2",
-    "coloredlogs>=15.0.1",
     "pyyaml>=6.0.2",
     "plotly>=5.24.1",
     "ipywidgets>=8.1.5",

--- a/src/cpg_flow/utils.py
+++ b/src/cpg_flow/utils.py
@@ -37,7 +37,6 @@ ExpectedResultT = Union[Path, dict[str, Path], dict[str, str], str, None]
 
 
 def format_logger(
-    logger_instance: 'Logger',
     log_level: int = logger.level('INFO').no,
     fmt_string: str = DEFAULT_LOG_FORMAT,
     coloured: bool = COLOURED_LOGS,
@@ -53,18 +52,22 @@ def format_logger(
     This helper method formats the logger instance with the given parameters, stripping out any previous handlers
     Because the global logger instance is modified, there is no return value
 
+    >>> from loguru import logger
+    >>> from cpg_flow.utils import format_logger
+    >>> format_logger(log_level=10, fmt_string='{time} {level} {message}', coloured=True)
+    >>> logger.info('This is an info message')
+
     Args:
-        logger_instance (Logger): the loguru logger instance to format
         log_level (int): logging level, defaults to INFO. Can be overridden by config
         fmt_string (str): format string for this logger, defaults to DEFAULT_LOG_FORMAT
         coloured (bool): whether to colour the logger output
     """
 
     # Remove any previous loguru handlers
-    logger_instance.remove()
+    logger.remove()
 
     # Add loguru handler with given format and level
-    logger_instance.add(
+    logger.add(
         sys.stdout,
         level=log_level,
         format=fmt_string,

--- a/uv.lock
+++ b/uv.lock
@@ -526,18 +526,6 @@ wheels = [
 ]
 
 [[package]]
-name = "coloredlogs"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "humanfriendly" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018 },
-]
-
-[[package]]
 name = "comm"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -628,7 +616,6 @@ wheels = [
 name = "cpg-flow"
 source = { editable = "." }
 dependencies = [
-    { name = "coloredlogs" },
     { name = "cpg-utils" },
     { name = "grpcio" },
     { name = "grpcio-status" },
@@ -666,12 +653,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coloredlogs", specifier = ">=15.0.1" },
     { name = "cpg-utils", specifier = ">=5.0.11" },
     { name = "grpcio", specifier = ">=1.53.0" },
     { name = "grpcio-status", specifier = ">=1.48,<1.50" },
     { name = "hail", specifier = "==0.2.134" },
     { name = "ipywidgets", specifier = ">=8.1.5" },
+    { name = "loguru", specifier = ">0.7.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "metamist", specifier = ">=6.9.0" },
     { name = "networkx", specifier = ">=3.4.2" },
@@ -1241,18 +1228,6 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/6c/eae99ba9422f90a2b86f1f309099e3504c19ee76f7401625fb47bd49f228/hail-0.2.134-py3-none-any.whl", hash = "sha256:75289519fa79d3eede93aa1de9b1ef29307e01eeb3ac99bcc5d5d94f949c2e81", size = 144929795 },
-]
-
-[[package]]
-name = "humanfriendly"
-version = "10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794 },
 ]
 
 [[package]]
@@ -2453,15 +2428,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216 },
-]
-
-[[package]]
-name = "pyreadline3"
-version = "3.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178 },
 ]
 
 [[package]]


### PR DESCRIPTION
loguru only has a single global instance, so named loggers/cached returns aren't a concept that works. 

There's a sketchy code path in the other PR as it stands:

```
# no arguments, returns a logger with default params. Caches the result
logger = get_logger()
print(id(logger))

# Add a formatting argument, clears prior formatting and returns the same global instance with a different string format
logger_2 = get_logger(log_fmt='XXX')
print(id(logger_2))


# no arguments again, returns cached result, but the object ID is global, so will actually return the logger_2 configuration
logger_3 = get_logger()
print(id(logger_3))

print(id(logger) == id(logger_2) == id(logger_3))
> True

print(logger is logger_2)
> True
```

I've tried changing up this 'configure and return a new instance' method into a 'apply configurations to the global instance' method, with docstring to match.

I tried using `copy.deepcopy` to make a genuinely different instance, and I got hit with a pickling issue. If we can't have multiple versions of this logger, best to lean into what we can do, which is tailor the formatting

