### PR TITLE
Switch to trusted publisher for PyPi and fix publish step

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - alpha
-      - SET-490-Fix-PyPi-Publish
 
   workflow_dispatch:
     inputs:
@@ -53,7 +52,7 @@ jobs:
 
       - name: Publish | Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.12.4
-        # if: steps.release.outputs.released == 'true' || github.event.inputs.force_pypi_release == 'true'
+        if: steps.release.outputs.released == 'true' || github.event.inputs.force_pypi_release == 'true'
 
       - name: Publish | Upload to GitHub Release Assets
         uses: python-semantic-release/publish-action@v9.21.0

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Action | Semantic Version Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9.14.0
+        uses: python-semantic-release/python-semantic-release@v9.21.0
         with:
           root_options: '-v'
           git_committer_email: 'software-team+githubcibot@populationgenomics.org.au'
@@ -46,18 +46,18 @@ jobs:
           github_token: ${{ secrets.BOT_ACCESS_TOKEN }}
 
       - name: Publish | Upload package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.2
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         # if: steps.release.outputs.released == 'true' || github.event.inputs.force_pypi_release == 'true'
 
       - name: Publish | Upload to GitHub Release Assets
-        uses: python-semantic-release/publish-action@v9.8.9
+        uses: python-semantic-release/publish-action@v9.21.0
         if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.BOT_ACCESS_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v5.4.1
 
       - name: Install project dependencies
         run: |

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - alpha
+      - SET-490-Fix-PyPi-Publish
 
   workflow_dispatch:
     inputs:
@@ -46,7 +47,7 @@ jobs:
 
       - name: Publish | Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.12.2
-        if: steps.release.outputs.released == 'true' || github.event.inputs.force_pypi_release == 'true'
+        # if: steps.release.outputs.released == 'true' || github.event.inputs.force_pypi_release == 'true'
 
       - name: Publish | Upload to GitHub Release Assets
         uses: python-semantic-release/publish-action@v9.8.9

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -45,6 +45,12 @@ jobs:
           git_committer_name: 'cpg-software-ci-bot'
           github_token: ${{ secrets.BOT_ACCESS_TOKEN }}
 
+      - name: Build on no release
+        if: steps.release.outputs.released != 'true'
+        run: |
+          echo "No release was made, manual build"
+          make ci-build
+
       - name: Publish | Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.12.4
         # if: steps.release.outputs.released == 'true' || github.event.inputs.force_pypi_release == 'true'

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -5,6 +5,14 @@ on:
       - main
       - alpha
 
+  workflow_dispatch:
+    inputs:
+      force_pypi_release:
+        description: 'Force PyPi publish'
+        required: false
+        default: false
+        type: boolean
+
 permissions:
   id-token: write
   contents: write
@@ -38,10 +46,7 @@ jobs:
 
       - name: Publish | Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@v1.12.2
-        if: steps.release.outputs.released == 'true'
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        if: steps.release.outputs.released == 'true' || github.event.inputs.force_pypi_release == 'true'
 
       - name: Publish | Upload to GitHub Release Assets
         uses: python-semantic-release/publish-action@v9.8.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -417,4 +417,4 @@ dev-dependencies = [
 
 [tool.setuptools_scm]
 version_scheme = "only-version"
-local_scheme = "node-and-date"
+local_scheme = "no-local-version"


### PR DESCRIPTION
This PR does two things:

1. Switch PyPi to using trusted publisher oidc tokens instead of the API_TOKEN
2. Fix the publish to PyPi

I'll be honest I have no idea what the issue was but updating all of the action steps to latest action versions and removing the local build tag seems to have done the trick.

```toml
[tool.setuptools_scm]
local_scheme = "no-local-version"
```

Not yet tested on main (obviously). I've added a one dummy "fix" commit at the end here to trigger a new version (even though it's just CI changes) so we can test it on merge to main.