### PR TITLE
Update mkdocs content

### DIFF
--- a/docs/docs/reference/utils.md
+++ b/docs/docs/reference/utils.md
@@ -2,7 +2,7 @@
 
 Utility functions and constants.
 
-::: cpg_flow.utils.get_logger
+::: cpg_flow.utils.format_logger
 
 ::: cpg_flow.utils.chunks
 


### PR DESCRIPTION
Following a recent removal of `get_logger`, the mkdocs CI failed due to the removed method still being an expected inclusion. 

I've swapped this over to `format_logger`, the new method.

This file looked auto-generated, does its content require a manual update?