### PR TITLE
fix: add a reciprocal multicohort link

### DIFF
--- a/src/cpg_flow/stage.py
+++ b/src/cpg_flow/stage.py
@@ -430,18 +430,6 @@ class Stage(Generic[TargetT], ABC):
         Can be a str, a Path object, or a dictionary of str/Path objects.
         """
 
-    # TODO: remove this method
-    def deprecated_queue_for_cohort(
-        self,
-        cohort: Cohort,
-    ) -> dict[str, StageOutput | None]:
-        """
-        Queues jobs for each corresponding target, defined by Stage subclass.
-        Returns a dictionary of `StageOutput` objects indexed by target unique_id.
-        unused, ready for deletion
-        """
-        return {}
-
     @abstractmethod
     def queue_for_multicohort(
         self,
@@ -724,7 +712,7 @@ class Stage(Generic[TargetT], ABC):
 
 
 def stage(
-    cls: type['Stage'] | None = None,
+    cls: type['Stage'] = None,
     *,
     analysis_type: str | None = None,
     analysis_keys: list[str | Path] | None = None,

--- a/src/cpg_flow/targets/dataset.py
+++ b/src/cpg_flow/targets/dataset.py
@@ -30,6 +30,7 @@ from cpg_utils.config import dataset_path, get_config, web_url
 
 if TYPE_CHECKING:
     from cpg_flow.targets import PedigreeInfo, Sex
+    from cpg_flow.targets.multicohort import MultiCohort
 
 
 class Dataset(Target):
@@ -42,21 +43,19 @@ class Dataset(Target):
     * a metamist project
     """
 
-    def __init__(
-        self,
-        name: str,
-    ):
+    def __init__(self, name: str, multicohort: 'MultiCohort'):
         super().__init__()
         self._sequencing_group_by_id: dict[str, SequencingGroup] = {}
         self.name = name
         self.active = True
+        self.multicohort = multicohort
 
     @staticmethod
-    def create(name: str) -> 'Dataset':
+    def create(name: str, multicohort: 'MultiCohort') -> 'Dataset':
         """
         Create a dataset.
         """
-        return Dataset(name=name)
+        return Dataset(name=name, multicohort=multicohort)
 
     @property
     def target_id(self) -> str:
@@ -207,7 +206,6 @@ class Dataset(Target):
         """
         return {
             'dataset': self.name,
-            # 'sequencing_groups': self.get_sequencing_group_ids(),
         }
 
     def get_job_prefix(self) -> str:

--- a/src/cpg_flow/workflow.py
+++ b/src/cpg_flow/workflow.py
@@ -252,7 +252,7 @@ class Workflow:
         Returns:
             Path
         """
-        return cohort.analysis_dataset.prefix(category=category) / self.name / cohort.id
+        return cohort.dataset.prefix(category=category) / self.name / cohort.id
 
     def run(
         self,


### PR DESCRIPTION
Closes #79
Closes #85 

https://batch.hail.populationgenomics.org.au/batches/594273

This is an unsolicited PR, so happy to back out of this and turn it into a discussion, but if so it should be prioritised - #79 is a very significant degradation from `cpg_workflows`

Adds in a multicohort instance to each Dataset and Cohort, so that these object instances can link to the run-wide MultiCohort without re-querying Metamist. This MultiCohort instance is passed when these smaller objects are created (mostly in the MultiCohort class methods - a `create_dataset(...)` method does exist, but I don't think it's used).

I was fiddling around a bit and swapped some `get_config()[index].get(index, default)` calls for `config_retrieve([index], default)` which is slightly cleaner.

During this I found something interesting: https://github.com/populationgenomics/cpg-flow/blob/main/src/cpg_flow/targets/cohort.py#L89

This is a dangling bug from https://github.com/populationgenomics/cpg-flow/pull/78 - the cohort objects still contain code which would write to `cohort.analysis_dataset` which no longer exists. My IDE noticed this, but static code inspection didn't. MyPy still doesn't find this during pre-commit, even if `cpg-flow` is explicitly added as a dependency 🤔 

![Screenshot 2025-04-16 at 6 06 42 PM](https://github.com/user-attachments/assets/72b0f5bc-d261-462d-84d7-b9e2fa2287ad)

I've also chucked in the line change from https://centrepopgen.slack.com/archives/C018KFBCR1C/p1744790224579469?thread_ts=1744778516.820329&cid=C018KFBCR1C so I can test the syntax on a workflow.