### PR TITLE
Add zizmor scanning for workflows

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,7 +41,9 @@ jobs:
       DOCKER_TMP: australia-southeast1-docker.pkg.dev/cpg-common/images-tmp
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Log the PR commit sha
         if: ${{ github.event_name == 'pull_request' }}
@@ -49,13 +51,13 @@ jobs:
 
       - id: 'google-cloud-auth'
         name: 'Authenticate to Google Cloud'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 #v2.1.10
         with:
           workload_identity_provider: 'projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
           service_account: 'gh-images-deployer@cpg-common.iam.gserviceaccount.com'
 
       - name: set up gcloud sdk
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a #v2.1.4
         with:
           project_id: cpg-common
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -16,17 +16,18 @@ on:
         description: 'Tag to use (defaults to "test")'
         default: 'test'
 
-permissions:
-  id-token: write
-  contents: read
-
 env:
   VERSION: 0.2.2
+
+permissions: {}
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      id-token: write
+      contents: read
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -85,10 +85,16 @@ jobs:
 
       - name: manually triggered build
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name != 'main' }}
+        env:
+          IMAGE_NAME: $IMAGE_NAME
+          DOCKER_DEV: $DOCKER_DEV
+          TAG: ${{ github.event.inputs.tag }}
+          SHA: ${{ github.sha }}
         run: |
-          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:${{ github.event.inputs.tag }}
-          docker push $DOCKER_DEV/$IMAGE_NAME:${{ github.event.inputs.tag }}
-          echo "DOCKER_IMAGE=$DOCKER_DEV/$IMAGE_NAME:${{ github.event.inputs.tag }}" >> $GITHUB_ENV
+          set -euo pipefail
+          docker tag "$IMAGE_NAME:$SHA" "$DOCKER_DEV/$IMAGE_NAME:$TAG"
+          docker push "$DOCKER_DEV/$IMAGE_NAME:$TAG"
+          echo "DOCKER_IMAGE=$DOCKER_DEV/$IMAGE_NAME:$TAG" >> "$GITHUB_ENV"
 
       - name: print docker tag
         run: echo "Pushed Docker Tag ${{ env.DOCKER_IMAGE }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,8 @@ name: Lint
 on:
   push:
 
+permissions: {}
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,12 +11,12 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
-          submodules: 'true'
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca #v6.0.1
 
       - name: Install Python
         run: uv python install

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -29,12 +29,18 @@ jobs:
 
     steps:
       - name: Setup | Force correct release branch on workflow sha
+        env:
+          REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git clone https://github.com/${{ github.repository }} .
-          git checkout -B ${{ github.ref_name }} ${{ github.sha }}
+          set -euo pipefail
+          git clone https://github.com/${REPO} .
+          git checkout -B "${REF_NAME}" "${SHA}"
           git config user.name "cpg-software-ci-bot"
           git config user.email "software-team+githubcibot@populationgenomics.org.au"
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}"
 
       - name: Action | Semantic Version Release
         id: release

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca #v6.0.1
+        with:
+          enable-cache: false
 
       - name: Install project dependencies
         run: |

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -13,15 +13,16 @@ on:
         default: false
         type: boolean
 
-permissions:
-  id-token: write
-  contents: write
+permissions: {}
 
 jobs:
   package:
     name: Package
     if: startsWith(github.event.head_commit.message, 'bump:') != true
     environment: production
+    permissions:
+      id-token: write
+      contents: write
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Action | Semantic Version Release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9.21.0
+        uses: python-semantic-release/python-semantic-release@0dc72ac9058a62054a45f6344c83a423d7f906a8 #v9.21.1
         with:
           root_options: '-v'
           git_committer_email: 'software-team+githubcibot@populationgenomics.org.au'
@@ -52,18 +52,18 @@ jobs:
           make ci-build
 
       - name: Publish | Upload package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc #v1.12.4
         if: steps.release.outputs.released == 'true' || github.event.inputs.force_pypi_release == 'true'
 
       - name: Publish | Upload to GitHub Release Assets
-        uses: python-semantic-release/publish-action@v9.21.0
+        uses: python-semantic-release/publish-action@1aa9f41fac5d531e6764e1991b536783337f3a56 #v9.21.1
         if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.BOT_ACCESS_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5.4.1
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca #v6.0.1
 
       - name: Install project dependencies
         run: |

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -12,17 +12,19 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e #v2.0.6
         id: app-token
         with:
           app-id: ${{ vars.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
+        with:
+          persist-credentials: false
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v40.3.5
+        uses: renovatebot/github-action@e854b273e774bce1ef8cb05f128b8ce8aee2a887 #v42.0.1
         with:
           token: '${{ steps.app-token.outputs.token }}'
           docker-user: root

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -4,13 +4,14 @@ on:
     - cron: '0 0 * * Sun'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e #v2.0.6
         id: app-token

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -19,7 +19,7 @@ jobs:
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca #v6.0.1
 
       - name: Run zizmor 🌈
-        run: uvx zizmor --format=sarif . > results.sarif
+        run: uvx zizmor@1.6.0 --format=sarif . > results.sarif
 
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca #v6.0.1
 
       - name: Install project dependencies
         run: |
@@ -23,3 +23,29 @@ jobs:
         with:
           virtual-environment: .venv
           summary: true
+
+  zizmor:
+    name: Zizmor Scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca #v6.0.1
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format=sarif . > results.sarif
+
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Pip Audit
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca #v6.0.1
@@ -19,7 +21,7 @@ jobs:
           uv sync
           source .venv/bin/activate
 
-      - uses: pypa/gh-action-pip-audit@v1.1.0
+      - uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 #v1.1.0
         with:
           virtual-environment: .venv
           summary: true
@@ -31,7 +33,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
 
+permissions: {}
+
 jobs:
   pip-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,8 @@ on:
   # publishing only to main pushes and manual dispatch with `if`s in specific steps.
   push:
 
+permissions: {}
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,12 +12,12 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           submodules: 'true'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca #v6.0.1
 
       - name: Install project dev dependencies
         run: uv sync --only-dev
@@ -32,13 +32,13 @@ jobs:
           echo "rc=$rc" >> $GITHUB_OUTPUT
 
       - name: 'Save coverage report as an Artifact'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.3.0
         with:
           name: coverage-report
           path: ./coverage.xml
 
       - name: 'Save execution report as an Artifact'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.3.0
         with:
           name: execution-report
           path: ./test-execution.xml
@@ -62,14 +62,14 @@ jobs:
           cat badge_data.env
 
       - name: 'Save badge data as an Artifact'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.3.0
         with:
           name: badge-data
           path: ./badge_data.env
 
       - name: Fail if unit tests are not passing
         if: ${{ steps.runtests.outputs.rc != 0}}
-        uses: actions/github-script@v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
         with:
           script: |
             core.setFailed('Unittests failed with rc = ${{ steps.runtests.outputs.rc }}')
@@ -81,18 +81,18 @@ jobs:
     environment: production
     if: github.ref_name == 'main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       # Download the coverage report artifact
       - name: 'Download coverage and execution report'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #4.3.0
         with:
           pattern: '*-report'
 
       # Perform the SonarQube scan
-      - uses: sonarsource/sonarqube-scan-action@master
+      - uses: sonarsource/sonarqube-scan-action@2500896589ef8f7247069a56136f8dc177c27ccf #v5.2.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,8 +29,8 @@ jobs:
         id: runtests
         timeout-minutes: 20
         run: |
-          uv run coverage run -m pytest tests --junitxml=test-execution.xml
-          rc=$?
+          rc=0
+          uv run coverage run -m pytest tests --junitxml=test-execution.xml || rc=$?
           uv run coverage xml
           echo "rc=$rc" >> $GITHUB_OUTPUT
 
@@ -73,9 +73,11 @@ jobs:
       - name: Fail if unit tests are not passing
         if: ${{ steps.runtests.outputs.rc != 0}}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        env:
+          rc: ${{ steps.runtests.outputs.rc }}
         with:
           script: |
-            core.setFailed('Unittests failed with rc = ${{ steps.runtests.outputs.rc }}')
+            core.setFailed(`Unittests failed with rc = ${process.env.rc}`)
 
   sonarqube:
     name: SonarQube scan

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           submodules: 'true'
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca #v6.0.1
@@ -84,6 +85,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
 
       # Download the coverage report artifact
       - name: 'Download coverage and execution report'

--- a/.github/workflows/web-docs.yaml
+++ b/.github/workflows/web-docs.yaml
@@ -4,11 +4,14 @@ on:
     branches:
       - alpha
       - main
-permissions:
-  contents: write
+
+permissions: {}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:

--- a/.github/workflows/web-docs.yaml
+++ b/.github/workflows/web-docs.yaml
@@ -10,14 +10,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
+
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca #v6.0.1
 
       - name: Install project dependencies
         run: |
@@ -25,7 +28,7 @@ jobs:
           source .venv/bin/activate
 
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache


### PR DESCRIPTION
This PR adds a `zizmor` workflow scanning job to the Security checks, and I have also set up code scanning for the repo now. I think the results are in a much nicer format here than over a pre-commit hook. Would love to get opinions on how this setup looks. Can't imagine this would be disruptive since we do not expect frequent modifications to our workflows. I have also made the appropriate changes to improve our workflows based on feedback from `zizmor`.