### PR TITLE
ci(cleanup-sonarqube): fix curl command

### DIFF
--- a/.github/workflows/cleanup-sonarqube-project.yaml
+++ b/.github/workflows/cleanup-sonarqube-project.yaml
@@ -38,10 +38,13 @@ jobs:
         run: |
           PR_PROJECT_KEY="${{ steps.basekey.outputs.base_key }}-pr-${{ steps.branch.outputs.name }}"
           echo "Deleting SonarQube project: $PR_PROJECT_KEY"
-          curl -s -f -u "${{ secrets.SONAR_GLOBAL_TOKEN }}:" \
-            -X POST "${{ vars.SONAR_HOST_URL }}/api/projects/delete?project=${PR_PROJECT_KEY}"
-          if [ $? -eq 0 ]; then
+
+          response=$(curl -s -H "Authorization: Bearer ${{ secrets.SONAR_ADMIN_TOKEN }}" \
+            "https://sonarqube.populationgenomics.org.au/api/projects/search?projects=${PR_PROJECT_KEY}")
+
+          if [ "$response" -eq 204 ]; then
             echo "Project $PR_PROJECT_KEY deleted successfully."
           else
-            echo "Project $PR_PROJECT_KEY not found or already deleted."
+            echo "Failed to delete project $PR_PROJECT_KEY. HTTP status: $response"
+            cat response.txt
           fi


### PR DESCRIPTION
You need an admin token in order to delete, the global token failed. Also the format was wrong for sending the token, it needed to be in the Authorization: Bearer header.