### PR TITLE
Pyright type checking issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,11 @@ repos:
           ]
         additional_dependencies: [types-PyYAML==6.0.4, types-toml]
 
+  # - repo: https://github.com/RobertCraigie/pyright-python
+  #   rev: v1.1.400
+  #   hooks:
+  #     - id: pyright
+
   - repo: https://github.com/opensource-nepal/commitlint
     rev: v1.3.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,11 @@ cpg = [
 [tool.coverage.run]
 omit = ["test/*", "setup.py"]
 
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+typeCheckingMode = "basic"
+
 [tool.semantic_release]
 version_variables = [
     "src/__init__.py:__version__",


### PR DESCRIPTION
Currently different developers and users of cpg-flow have different Pyright settings in their editors (like vscode). Specifically Pyright's strict setting reveals _a lot_ of type issues in cpg-flow.

This pr is to resolve those type issues as well as add a pyright type checker to the pre-commit hook forcing everyone to the same settings and standard regardless of their local vscode/editor setup.