### PR TITLE
fix(cohort_dataset): correction to syntax

### DIFF
--- a/src/cpg_flow/workflow.py
+++ b/src/cpg_flow/workflow.py
@@ -237,7 +237,7 @@ class Workflow:
         """
         Prepare a unique path for the workflow with this name and this input data.
         """
-        return get_multicohort().analysis_dataset.prefix(category=category) / self.name / self.output_version
+        return get_multicohort().dataset.prefix(category=category) / self.name / self.output_version
 
     def cohort_prefix(self, cohort: Cohort, category: str | None = None) -> Path:
         """


### PR DESCRIPTION
Closes #98 

Follow up patch to #78, issue described in #98

Corrects the outdated use of `cohort.analysis_dataset` to `cohort.dataset`