### PR TITLE
SET-513 Implement prefix method for CohortStage 

### DIFF
--- a/src/cpg_flow/targets/cohort.py
+++ b/src/cpg_flow/targets/cohort.py
@@ -24,7 +24,6 @@ from typing import TYPE_CHECKING
 import pandas as pd
 from loguru import logger
 
-from cpg_flow.inputs import get_multicohort
 from cpg_flow.targets import Dataset, Target
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, dataset_path, get_config
@@ -76,6 +75,7 @@ class Cohort(Target):
         The inclusion of the multicohort hash is determined when this method is called.
         The inclusion of the workflow name is determined by the config.
         """
+        from cpg_flow.inputs import get_multicohort
 
         path_elements = []
 

--- a/src/cpg_flow/targets/cohort.py
+++ b/src/cpg_flow/targets/cohort.py
@@ -79,7 +79,7 @@ class Cohort(Target):
 
         path_elements = []
 
-        if workflow_name := config_retrieve(['workflow', 'name'], default=None)
+        if workflow_name := config_retrieve(['workflow', 'name'], default=None):
             path_elements.append(workflow_name)
 
         if unique_for_multicohort:

--- a/src/cpg_flow/targets/cohort.py
+++ b/src/cpg_flow/targets/cohort.py
@@ -79,8 +79,7 @@ class Cohort(Target):
 
         path_elements = []
 
-        workflow_name = config_retrieve(['workflow', 'name'], default=None)
-        if workflow_name:
+        if workflow_name := config_retrieve(['workflow', 'name'], default=None)
             path_elements.append(workflow_name)
 
         if unique_for_multicohort:


### PR DESCRIPTION
**feat(cohort): add prefix() method with optional multicohort-aware pathing**

This change introduces a prefix() method to the Cohort class, mirroring the existing method in Dataset.

The method constructs the primary storage path for cohort-related outputs and supports toggling uniqueness per MultiCohort.

Key behaviour:
`cohort.prefix()` →
`gs://cpg-fewgenomes-test/cpg-flow_test`

`cohort.prefix(unique_for_multicohort=True)` →
`gs://cpg-fewgenomes-test/f7c346c351_1_cohorts/cpg-flow_test`

Further context: [SET-513](https://cpg-populationanalysis.atlassian.net/browse/SET-513)
Slack thread: https://centrepopgen.slack.com/archives/C051EPKNJH1/p1750722341060999

[SET-513]: https://cpg-populationanalysis.atlassian.net/browse/SET-513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ