### PR TITLE
Switch to images-dev for dev builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -39,7 +39,6 @@ jobs:
       IMAGE_NAME: cpg_flow
       DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
       DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images
-      DOCKER_TMP: australia-southeast1-docker.pkg.dev/cpg-common/images-tmp
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
@@ -73,9 +72,9 @@ jobs:
       - name: push commit sha tag
         if: ${{ github.ref_name != 'main' && github.ref_name != 'alpha' }}
         run: |
-          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_TMP/$IMAGE_NAME:${{ github.event.pull_request.head.sha }}
-          docker push $DOCKER_TMP/$IMAGE_NAME:${{ github.event.pull_request.head.sha }}
-          echo "DOCKER_IMAGE=$DOCKER_TMP/$IMAGE_NAME:${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:${{ github.event.pull_request.head.sha }}
+          docker push $DOCKER_DEV/$IMAGE_NAME:${{ github.event.pull_request.head.sha }}
+          echo "DOCKER_IMAGE=$DOCKER_DEV/$IMAGE_NAME:${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
       - name: push production on version bump
         if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'alpha') && startsWith(github.event.head_commit.message, 'bump:') }}


### PR DESCRIPTION
Previous version of our docker workflow pushed to the tmp registry not the dev registry. This change completes that switch.