### PR TITLE
Disable upgrades of python and hail

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -22,6 +22,16 @@
   },
   "packageRules": [
     {
+      "matchManagers": [
+        "pep621"
+      ],
+      "matchPackageNames": [
+        "python",
+        "hail"
+      ],
+      "enabled": false
+    },
+    {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "matchUpdateTypes": [


### PR DESCRIPTION
Current renovate config allows suggesting upgrades to Python and Hail both of which we prefer to upgrade at our own discretion. This change disables those suggestions.