### PR TITLE
feat(skipping): create faster unsafe skipping logic

### DIFF
--- a/src/cpg_flow/defaults.toml
+++ b/src/cpg_flow/defaults.toml
@@ -53,6 +53,13 @@ check_inputs = true
 # that are missing results from skipped stages.
 skip_sgs_with_missing_input = false
 
+# The default behaviour of cpg_flow is to generate expected outputs for every Stage, even if that Stage is skipped.
+# This is used to fail the workflow if expected outputs do not exist, and the stage is skipped.
+# If this variable is set to true, it will not generate expected outputs for skipped stages.
+# This can lead to faster workflow setup, but may cause issues if outputs from skipped stages have not been created,
+# are expected by later stages, if those later stages are not skipped.
+unsafe_skipping = true
+
 # Within jobs, check all in-job intermediate files for possible reuse.
 # If set to False, will overwrite all intermediates. Used by `utils.can_reuse(path)`.
 check_intermediates = true


### PR DESCRIPTION
CPG-Flow, and production-pipelines before it, generates expected_outputs from every Stage, even when the Stage is due to be skipped. 

This can create massive slowdowns setting off runs in large cohorts, as potentially 10s of thousands of file paths have to be generated, and checked for existence, even if the Stage cannot be un-skipped.

This behaviour changes two events:

-  In `_get_action`, if the Stage is marked as Skipped, and `workflow.unsafe_skipping` is True, we never generate the expected outputs for the Stage. Stage skipping is a configured behaviour, and this boolean flag means that we don't want the workflow to generate all the outputs just to print a message about whether the Stage can be skipped safely
- In `_queue_jobs_with_checks` the workflow currently regenerates all the expected outputs again, just to return None anyway a few lines later for skipped stages. This brings that logic up a few lines, saving the effort of computing the outputs of skipped stages