### PR TITLE
Optionally intercept standard Python logging and redirect to loguru handler

### DIFF
--- a/src/cpg_flow/utils.py
+++ b/src/cpg_flow/utils.py
@@ -3,6 +3,8 @@ Utility functions and constants.
 """
 
 import hashlib
+import inspect
+import logging
 import re
 import string
 import sys
@@ -32,13 +34,31 @@ DEFAULT_LOG_FORMAT = config_retrieve(
 )
 
 COLOURED_LOGS = config_retrieve(['workflow', 'coloured_logs'], False)
+INTERCEPT_LOGGING = config_retrieve(['workflow', 'intercept_logging'], True)
 ExpectedResultT = Union[Path, dict[str, str | Path | list[str | Path]], str, None]
+
+
+class _LoguruInterceptHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        frame = inspect.currentframe()
+        depth = 0
+        while frame and (depth == 0 or frame.f_code.co_filename == logging.__file__):
+            frame = frame.f_back
+            depth += 1
+
+        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
 def format_logger(
     log_level: int = logger.level('INFO').no,
     fmt_string: str = DEFAULT_LOG_FORMAT,
     coloured: bool = COLOURED_LOGS,
+    intercept_logging: bool = INTERCEPT_LOGGING,
 ) -> None:
     """
     loguru is a cleaner interface than the standard logging module, but it doesn't allow for multiple instances
@@ -73,6 +93,10 @@ def format_logger(
         colorize=coloured,
         enqueue=True,
     )
+
+    if intercept_logging:
+        # Intercept standard Python logging and redirect to loguru handler
+        logging.basicConfig(handlers=[_LoguruInterceptHandler()], level=0, force=True)
 
 
 def chunks(iterable, chunk_size) -> Iterator[Any]:


### PR DESCRIPTION
As per the [loguru documentation](https://loguru.readthedocs.io/en/stable/overview.html#entirely-compatible-with-standard-logging).

See [batch 631674](https://batch.hail.populationgenomics.org.au/batches/631674/jobs/1) which ran on an image that includes this PR — note the log ends with log messages from modules within `/cpg-flow/.venv/lib/…` whereas [batch 631672](https://batch.hail.populationgenomics.org.au/batches/631672/jobs/1) is of similar vintage but does not contain this PR and omits these log messages.

Before merging this, we would need to consider whether we facilitate cpg-flow-using workflows that prefer standard logging rather than loguru, and what the desired behaviour there would be — perhaps to redirect cpg-flow's loguru messages to the standard logger instead.