### PR TITLE
Support FastQ.ora files

### DIFF
--- a/src/cpg_flow/filetypes.py
+++ b/src/cpg_flow/filetypes.py
@@ -252,10 +252,10 @@ class FastqOraPair(AlignmentInput):
 
     def __repr__(self):
         """
-        Glob string to find all FASTQ files.
+        Glob string to find all FASTQ.ora files.
 
-        >>> str(FastqPair('gs://sequencing_group_R1.fq.gz', 'gs://sequencing_group_R2.fq.gz'))
-        'gs://sequencing_group_R{1,2}.fq.gz'
+        >>> str(FastqOraPair('gs://sequencing_group_R1.fq.ora', 'gs://sequencing_group_R2.fq.ora'))
+        'gs://sequencing_group_R{1,2}.fq.ora'
         """
         return ''.join(
             f'{{{",".join(sorted(set(chars)))}}}' if len(set(chars)) > 1 else chars[0]

--- a/src/cpg_flow/filetypes.py
+++ b/src/cpg_flow/filetypes.py
@@ -228,7 +228,42 @@ class FastqPair(AlignmentInput):
         )
 
 
-class FastqPairs(list[FastqPair], AlignmentInput):
+@dataclass
+class FastqOraPair(AlignmentInput):
+    def __init__(self, r1_path: FastqPath, r2_path: FastqPath, reference_assembly: str | Path):
+        self.reference_assembly = reference_assembly
+        self.fq_pair = FastqPair(r1_path, r2_path)
+
+    def as_resources(self, b) -> 'FastqPair':
+        """
+        Makes a trio of ResourceFile objects for r1, r2, and a reference assembly.
+        """
+        return b.read_input_group(
+            r1=self.fq_pair.r1,
+            r2=self.fq_pair.r2,
+            reference=self.reference_assembly,
+        )
+
+    def exists(self) -> bool:
+        """
+        Check if each FASTQ.ora file in the pair, and the reference, exists.
+        """
+        return all(exists(file) for file in [self.fq_pair.r1, self.fq_pair.r2, self.reference_assembly])
+
+    def __repr__(self):
+        """
+        Glob string to find all FASTQ files.
+
+        >>> str(FastqPair('gs://sequencing_group_R1.fq.gz', 'gs://sequencing_group_R2.fq.gz'))
+        'gs://sequencing_group_R{1,2}.fq.gz'
+        """
+        return ''.join(
+            f'{{{",".join(sorted(set(chars)))}}}' if len(set(chars)) > 1 else chars[0]
+            for chars in zip(str(self.fq_pair.r1), str(self.fq_pair.r2), strict=False)
+        )
+
+
+class FastqPairs(list[FastqPair | FastqOraPair], AlignmentInput):
     """
     Multiple FASTQ file pairs belonging to the same sequencing_group
     (e.g. multiple lanes or top-ups).

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -18,10 +18,10 @@ from tenacity import (
     wait_exponential,
 )
 
-from cpg_flow.filetypes import AlignmentInput, BamPath, CramPath, FastqPair, FastqPairs
+from cpg_flow.filetypes import AlignmentInput, BamPath, CramPath, FastqPair, FastqPairs, FastqOraPair
 from cpg_flow.utils import exists
 from cpg_utils import Path, to_path
-from cpg_utils.config import get_config
+from cpg_utils.config import config_retrieve, get_config
 from metamist import models
 from metamist.apis import AnalysisApi
 from metamist.exceptions import ApiException, ServiceException
@@ -126,6 +126,7 @@ GET_PEDIGREE_QUERY = gql(
     """,
 )
 
+SUPPORTED_READ_TYPES = {'bam', 'cram', 'fastq', 'fastq_ora'}
 
 _metamist: Optional['Metamist'] = None
 
@@ -567,10 +568,9 @@ def parse_reads(
             f'{sequencing_group_id}: supporting only single bam/cram input',
         )
 
-    supported_types = {'fastq', 'bam', 'cram'}
-    if reads_type not in supported_types:
+    if reads_type not in SUPPORTED_READ_TYPES:
         raise MetamistError(
-            f'{sequencing_group_id}: ERROR: "reads_type" is expected to be one of {sorted(supported_types)}',
+            f'{sequencing_group_id}: ERROR: "reads_type" is expected to be one of {SUPPORTED_READ_TYPES}',
         )
 
     if reads_type in {'bam', 'cram'}:
@@ -579,13 +579,24 @@ def parse_reads(
             sequencing_group_id,
             check_existence,
             reference_assembly,
-            access_level=get_config()['workflow']['access_level'],
+            access_level=config_retrieve(['workflow', 'access_level']),
         )
+
+    # special handling case for FQ.ora files, these require a reference for decompression
+    elif reads_type == 'fastq_ora':
+        if (ora_reference := assay_meta.get('ora_reference')) is None or (
+            reference_location := ora_reference.get('location')
+        ) is None:
+            raise MetamistError(f'"meta.ora_reference.location" is mandatory for {reads_type} assays: \n{assay_meta}')
+        return find_fastqs(reads_data, ora_reference, check_existence, reference_location)
+
     else:
-        return find_fastqs(reads_data, sequencing_group_id, check_existence)
+        return find_fastqs(reads_data, sequencing_group_id, check_existence, reads_type)
 
 
-def find_fastqs(reads_data: list[dict], sequencing_group_id: str, check_existence: bool) -> FastqPairs:
+def find_fastqs(
+    reads_data: list[dict], sequencing_group_id: str, check_existence: bool, read_reference: str | None = None
+) -> FastqPairs:
     fastq_pairs = FastqPairs()
 
     for lane_pair in reads_data:
@@ -596,21 +607,33 @@ def find_fastqs(reads_data: list[dict], sequencing_group_id: str, check_existenc
                 f'but got {len(lane_pair)}. '
                 f'Read data: {pprint.pformat(lane_pair)}',
             )
-        if check_existence and not exists(lane_pair[0]['location']):
+        r1_file = lane_pair[0]['location']
+        r2_file = lane_pair[1]['location']
+
+        if check_existence and not exists(r1_file):
             raise MetamistError(
                 f'{sequencing_group_id}: ERROR: read 1 file does not exist: {lane_pair[0]["location"]}',
             )
-        if check_existence and not exists(lane_pair[1]['location']):
+        if check_existence and not exists(r2_file):
             raise MetamistError(
                 f'{sequencing_group_id}: ERROR: read 2 file does not exist: {lane_pair[1]["location"]}',
             )
 
-        fastq_pairs.append(
-            FastqPair(
-                to_path(lane_pair[0]['location']),
-                to_path(lane_pair[1]['location']),
-            ),
-        )
+        if read_reference is not None:
+            fastq_pairs.append(
+                FastqOraPair(
+                    to_path(lane_pair[0]['location']),
+                    to_path(lane_pair[1]['location']),
+                    read_reference,
+                ),
+            )
+        else:
+            fastq_pairs.append(
+                FastqPair(
+                    to_path(lane_pair[0]['location']),
+                    to_path(lane_pair[1]['location']),
+                ),
+            )
 
     return fastq_pairs
 

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -619,11 +619,11 @@ def find_fastqs(
 
         if check_existence and not exists(r1_file):
             raise MetamistError(
-                f'{sequencing_group_id}: ERROR: read 1 file does not exist: {lane_pair[0]["location"]}',
+                f'{sequencing_group_id}: ERROR: read 1 file does not exist: {r1_file}',
             )
         if check_existence and not exists(r2_file):
             raise MetamistError(
-                f'{sequencing_group_id}: ERROR: read 2 file does not exist: {lane_pair[1]["location"]}',
+                f'{sequencing_group_id}: ERROR: read 2 file does not exist: {r2_file}',
             )
 
         if read_reference is not None:

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -554,7 +554,6 @@ def parse_reads(
     reads_data = assay_meta.get('reads')
     reads_type = assay_meta.get('reads_type')
     reference_assembly = assay_meta.get('reference_assembly', {}).get('location')
-    ora_reference = assay_meta.get('ora_reference', {}).get('location')
 
     if not reads_data:
         raise MetamistError(f'{sequencing_group_id}: no "meta/reads" field in meta')

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -18,7 +18,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from cpg_flow.filetypes import AlignmentInput, BamPath, CramPath, FastqPair, FastqPairs, FastqOraPair
+from cpg_flow.filetypes import AlignmentInput, BamPath, CramPath, FastqOraPair, FastqPair, FastqPairs
 from cpg_flow.utils import exists
 from cpg_utils import Path, to_path
 from cpg_utils.config import config_retrieve, get_config

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -629,16 +629,16 @@ def find_fastqs(
         if read_reference is not None:
             fastq_pairs.append(
                 FastqOraPair(
-                    to_path(lane_pair[0]['location']),
-                    to_path(lane_pair[1]['location']),
+                    to_path(r1_file),
+                    to_path(r2_file),
                     read_reference,
                 ),
             )
         else:
             fastq_pairs.append(
                 FastqPair(
-                    to_path(lane_pair[0]['location']),
-                    to_path(lane_pair[1]['location']),
+                    to_path(r1_file),
+                    to_path(r2_file),
                 ),
             )
 

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -588,10 +588,10 @@ def parse_reads(
             reference_location := ora_reference.get('location')
         ) is None:
             raise MetamistError(f'"meta.ora_reference.location" is mandatory for {reads_type} assays: \n{assay_meta}')
-        return find_fastqs(reads_data, ora_reference, check_existence, reference_location)
+        return find_fastqs(reads_data, sequencing_group_id, check_existence, read_reference=reference_location)
 
     else:
-        return find_fastqs(reads_data, sequencing_group_id, check_existence, reads_type)
+        return find_fastqs(reads_data, sequencing_group_id, check_existence)
 
 
 def find_fastqs(

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -553,6 +553,7 @@ def parse_reads(
     """
     reads_data = assay_meta.get('reads')
     reads_type = assay_meta.get('reads_type')
+    reference_assembly = assay_meta.get('reference_assembly', {}).get('location')
     ora_reference = assay_meta.get('ora_reference', {}).get('location')
 
     if not reads_data:
@@ -578,7 +579,7 @@ def parse_reads(
             reads_data,
             sequencing_group_id,
             check_existence,
-            ora_reference,
+            reference_assembly,
             access_level=config_retrieve(['workflow', 'access_level']),
         )
 

--- a/src/cpg_flow/workflow.py
+++ b/src/cpg_flow/workflow.py
@@ -34,7 +34,7 @@ from cpg_flow.status import MetamistStatusReporter
 from cpg_flow.targets import Cohort, MultiCohort
 from cpg_flow.utils import format_logger, slugify, timestamp, write_to_gcs_bucket
 from cpg_utils import Path
-from cpg_utils.config import get_config, config_retrieve
+from cpg_utils.config import config_retrieve, get_config
 from cpg_utils.hail_batch import get_batch, reset_batch
 
 URL_BASENAME = 'https://{access_level}-web.populationgenomics.org.au/{name}/'


### PR DESCRIPTION
We have been sent some fastq.ora files from collaborators. These use a lossless compression algorithm from Illumina to reduce the footprint of unaligned reads files. 

These need to be handled separately in our pipeline in a few ways:
   - the reads need to be combined with a reference for decompression
   - the reads are of assay type `fastq_ora`, which is not currently handled
   - the localised resource group should contain [R1, R2, reference] for each read file to support decompression through`orad`

This change:

- adds `fastq_ora` as a supported enum
- adds a `FastqOraPair` as a new cpg-flow Filetype, highly similar to the FastqPair Dataclass, but different enough to keep it separate
- adds `FastqOraPair` as a union type in the `FastqPairs` container type (list of Fastq*)
- requires `fastq_ora` files to have an accompanying `meta.ora_reference.location`
- uses the same `find_fastqs` method for Fastq or FastqOra, creating the file object pairs as appropriate
- adds a parsing test for fastq_ora data

Related Epic: https://cpg-populationanalysis.atlassian.net/browse/RD-65
Specific ticket: https://cpg-populationanalysis.atlassian.net/browse/RD-288