### PR TITLE
fix(type): changes the FastQOra resource group return type

### DIFF
--- a/src/cpg_flow/filetypes.py
+++ b/src/cpg_flow/filetypes.py
@@ -234,7 +234,7 @@ class FastqOraPair(AlignmentInput):
         self.reference_assembly = reference_assembly
         self.fq_pair = FastqPair(r1_path, r2_path)
 
-    def as_resources(self, b) -> ResourceGroup:
+    def resource_group(self, b) -> ResourceGroup:
         """
         Makes a trio of ResourceFile objects for r1, r2, and a reference assembly.
         """

--- a/src/cpg_flow/filetypes.py
+++ b/src/cpg_flow/filetypes.py
@@ -234,7 +234,7 @@ class FastqOraPair(AlignmentInput):
         self.reference_assembly = reference_assembly
         self.fq_pair = FastqPair(r1_path, r2_path)
 
-    def as_resources(self, b) -> 'FastqPair':
+    def as_resources(self, b) -> ResourceGroup:
         """
         Makes a trio of ResourceFile objects for r1, r2, and a reference assembly.
         """


### PR DESCRIPTION
The FastQOra filetype was created with an `as_resources` classmethod, matching the FastQPair implementation. This was a poor choice, as the intended return type is a ResourceGroup. 

This change renames the method to `def resource_group(...)`, matching the GVCF method name and purpose, and gives an appropriate return type. 

This would be a breaking change, but the first and only consumer of this classmethod has not yet been implemented: https://github.com/populationgenomics/cpg-flow-align-genotype/pull/18. On that basis I'm expecting this to get a patch release version change to bump & release, but does not really need a minor/major version bump. 