### PR TITLE
fix(set_resources): remove wildcard in method signature

### DIFF
--- a/src/cpg_flow/resources.py
+++ b/src/cpg_flow/resources.py
@@ -67,7 +67,6 @@ class MachineType:
 
     def set_resources(
         self,
-        *,
         j: Job,
         fraction: float | None = None,
         ncpu: int | None = None,


### PR DESCRIPTION
The production-pipelines implementation ([here](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/resources.py#L74-L93)) had the method signature:

```
def set_resources(
        self,
        j: Job,
        fraction: float | None = None,
```

That method signature was changed in the liftover to:
```
def set_resources(
        self,
        *,
        j: Job,
        fraction: float | None = None,
        ...
```

Most/all of the uses of this method in code had the job as the first argument, often without keyword, e.g.

```res = STANDARD.set_resources(j, ncpu=nthreads, storage_gb=50)```

This syntax is no longer valid in CPG-Flow, as the `*` consumes the `job` parameter unless it is supplied with a keyword, giving the error:

```TypeError: MachineType.set_resources() takes 1 positional argument but 2 positional arguments (and 2 keyword-only arguments) were given```


This PR proposes changing back to the original syntax and removing the non-keyword argument consumer, as I can't see why the `*` was added.