### PR TITLE
fix(check_expected_outputs): switch default reuse behaviour

### DIFF
--- a/src/cpg_flow/stage.py
+++ b/src/cpg_flow/stage.py
@@ -728,8 +728,7 @@ class Stage(ABC, Generic[TargetT]):
             logger.debug('No expected outputs, assuming outputs exist')
             return True, None
 
-
-        # By default pipelines will reuse outputs. 
+        # By default pipelines will reuse outputs.
         if get_config()['workflow'].get('check_expected_outputs', True):
             paths = path_walk(expected_out)
             logger.info(


### PR DESCRIPTION
Closes #101 

I feel like we socially agreed to do this a while back, but never actually implemented it. 

`check_expected_outputs` is a parameter which determines how CPG-Flow workflows operate. If it is False, the pipeline will always run in full, not checking for existence of previously generated outputs. If it is True, the workflow acts 'normally', detecting prior outputs and continuing from them.

The `production-pipelines` behavior was to pre-load a default config file, which set this to True. CPG-Flow contains a default config suggestion [here](https://github.com/populationgenomics/cpg-flow/blob/main/src/cpg_flow/defaults.toml#L62), but doesn't load it when a pipeline runs. This config also sets `check_expected_outputs` to True, indicating that this would be the normal operating mode.

Because prod-pipes always loaded the default config, but cpg-flow doesn't, the altered behaviour is that every CPG-Flow implementing pipeline has to state `workflow.check_expected_outputs = true` in its own configuration file, otherwise every workflow will be a fresh run, overwriting any previous outputs. That's rarely the intended use case, and if a pipeline is to be repeated in full, that would be an elective behavior from the pipeline operator, and they would indicate that with `check_expected_outputs=false`.

General motivation for this change: If 99% of workflows have to add a config entry to get the normal workflow manager behavior, the default should be flipped. 