### PR TITLE
feat(metamist): flag all cohort fails once

### DIFF
--- a/src/cpg_flow/inputs.py
+++ b/src/cpg_flow/inputs.py
@@ -11,6 +11,7 @@ from cpg_flow.metamist import (
     AnalysisType,
     Assay,
     MetamistError,
+    check_for_inactive_cohorts,
     get_cohort_sgs,
     get_metamist,
     parse_reads,
@@ -115,6 +116,10 @@ def create_multicohort(custom_cohort_ids: tuple[str]) -> MultiCohort:
         logger.warning(f'Non-unique cohort IDs: {duplicated_cohort_ids}')
 
     multicohort = MultiCohort()
+
+    # flag inactive/invalid cohorts prior to querying
+    # if we change behaviour to allowing inactive cohorts, this should be relaxed/removed
+    check_for_inactive_cohorts(custom_cohort_ids_unique)
 
     # for each Cohort ID
     for cohort_id in custom_cohort_ids_unique:

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -32,7 +32,6 @@ COHORT_ACTIVE_CHECK = gql(
     query CohortActiveQuery($cohorts: [String!]!) {
         cohorts(id: {in_: $cohorts}) {
             id
-            description
             status
         }
     }

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -27,6 +27,18 @@ from metamist.apis import AnalysisApi
 from metamist.exceptions import ApiException, ServiceException
 from metamist.graphql import gql, query
 
+COHORT_ACTIVE_CHECK = gql(
+    """
+    query CohortActiveQuery($cohorts: [String!]!) {
+        cohorts(id: {in_: $cohorts}) {
+            id
+            description
+            status
+        }
+    }
+    """
+)
+
 GET_SEQUENCING_GROUPS_QUERY = gql(
     """
         query SGQuery($metamist_proj: String!, $only_sgs: [String!]!, $skip_sgs: [String!]!, $sequencing_type: String!){
@@ -506,6 +518,33 @@ class Assay:
                 check_existence=check_existence,
             )
         return mm_seq
+
+
+def check_for_inactive_cohorts(cohort_ids: list[str]) -> None:
+    """
+    Runs a check on all Cohort IDs being used as input - raises an error if any Cohorts are inactive.
+    Instead of detecting failing cohorts one by one (requiring reruns), this flags all cohorts which will cause
+    downstream failures.
+
+    Args:
+        cohort_ids(list[str]): Cohort IDs to use as input
+
+    Returns:
+        None, will fail if any Cohorts are inactive, and will print the offending cohorts
+    """
+    result = query(COHORT_ACTIVE_CHECK, {'cohorts': cohort_ids})
+
+    invalid_cohorts: list[str] = []
+
+    for cohort_result in result['data']['cohorts']:
+        if cohort_result['status'] != 'active':
+            invalid_cohorts.append(cohort_result['id'])
+
+    if invalid_cohorts:
+        raise MetamistError(
+            'Some Cohorts in the input list are inactive, only active cohorts are allowed.\n'
+            f'Inactive Cohorts: {invalid_cohorts}',
+        )
 
 
 def get_cohort_sgs(cohort_id: str) -> dict:

--- a/tests/assets/test_multicohort/cohort_check_bad.json
+++ b/tests/assets/test_multicohort/cohort_check_bad.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "cohorts": [
+      {
+        "id": "COH1",
+        "status": "active"
+      },
+      {
+        "id": "COH2",
+        "status": "invalid"
+      }
+    ]
+  }
+}

--- a/tests/assets/test_multicohort/cohort_check_good.json
+++ b/tests/assets/test_multicohort/cohort_check_good.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "cohorts": [
+      {
+        "id": "COH1",
+        "status": "active"
+      },
+      {
+        "id": "COH2",
+        "status": "active"
+      }
+    ]
+  }
+}

--- a/tests/test_cohort.py
+++ b/tests/test_cohort.py
@@ -106,6 +106,10 @@ def mock_get_analysis_by_sgs(*args, **kwargs) -> dict:
     return {}
 
 
+def mock_give_args_get_none(*args, **kwargs) -> None:
+    return None
+
+
 def mock_get_pedigree_empty(*args, **kwargs):
     return []
 
@@ -154,6 +158,7 @@ def test_input_cohorts_dont_exist(mocker: MockFixture, tmp_path, caplog):
     set_config(_cohort_config(tmp_path, cohort_ids=[missing_cohort_id]), tmp_path / 'config.toml')
 
     mocker.patch('cpg_flow.inputs.get_cohort_sgs', mock_get_cohort_sgs)
+    mocker.patch('cpg_flow.inputs.check_for_inactive_cohorts', mock_give_args_get_none)
 
     # Assert the value error is raised
     from cpg_flow.inputs import get_multicohort
@@ -189,6 +194,7 @@ def test_cohort(mocker: MockFixture, tmp_path, caplog):
     mocker.patch('cpg_flow.metamist.Metamist.get_analyses_by_sgid', mock_get_analysis_by_sgs)
 
     mocker.patch('cpg_flow.inputs.get_cohort_sgs', mock_get_cohort_sgs)
+    mocker.patch('cpg_flow.inputs.check_for_inactive_cohorts', mock_give_args_get_none)
 
     caplog.set_level(logging.WARNING)
 
@@ -264,6 +270,8 @@ def test_missing_reads(mocker: MockFixture, tmp_path):
 
     mocker.patch('cpg_flow.inputs.get_cohort_sgs', mock_get_cohort_sgs)
 
+    mocker.patch('cpg_flow.inputs.check_for_inactive_cohorts', mock_give_args_get_none)
+
     # from cpg_flow.filetypes import BamPath
     from cpg_flow.inputs import get_multicohort
     from cpg_flow.targets import Sex
@@ -334,6 +342,8 @@ def test_mixed_reads(mocker: MockFixture, tmp_path, caplog):
     )
     mocker.patch('cpg_flow.metamist.Metamist.get_analyses_by_sgid', mock_get_analysis_by_sgs)
 
+    mocker.patch('cpg_flow.inputs.check_for_inactive_cohorts', mock_give_args_get_none)
+
     mocker.patch('cpg_flow.inputs.get_cohort_sgs', mock_get_cohort_sgs)
 
     from cpg_flow.inputs import get_multicohort
@@ -380,6 +390,7 @@ def test_unknown_data(mocker: MockFixture, tmp_path, caplog):
     mocker.patch('cpg_flow.metamist.Metamist.get_analyses_by_sgid', mock_get_analysis_by_sgs)
 
     mocker.patch('cpg_flow.inputs.get_cohort_sgs', mock_get_cohort_sgs)
+    mocker.patch('cpg_flow.inputs.check_for_inactive_cohorts', mock_give_args_get_none)
 
     from cpg_flow.inputs import get_multicohort
     from cpg_flow.targets import Sex
@@ -420,6 +431,7 @@ def test_custom_cohort(mocker: MockFixture, tmp_path, monkeypatch):
         }
 
     monkeypatch.setattr('cpg_flow.metamist.query', mock_query)
+    mocker.patch('cpg_flow.inputs.check_for_inactive_cohorts', mock_give_args_get_none)
 
     from cpg_flow.inputs import get_multicohort
 

--- a/tests/test_metamist.py
+++ b/tests/test_metamist.py
@@ -5,7 +5,7 @@ Test workflow status reporter.
 import pytest
 from pytest_mock import MockFixture
 
-from cpg_flow.filetypes import FastqOraPair, FastqPair, FastqPairs
+from cpg_flow.filetypes import FastqOraPair, FastqPairs
 from cpg_flow.metamist import (
     Analysis,
     AnalysisStatus,

--- a/tests/test_multicohort.py
+++ b/tests/test_multicohort.py
@@ -5,11 +5,14 @@ Test reading inputs into a Cohort object.
 import json
 import logging
 
+import pytest
 from pytest_mock import MockFixture
 
 from cpg_flow.inputs import MultiCohort
+from cpg_flow.metamist import MetamistError, check_for_inactive_cohorts
 
 from tests import set_config
+from tests.test_cohort import mock_give_args_get_none
 
 LOGGER = logging.getLogger(__name__)
 
@@ -89,6 +92,7 @@ def test_multicohort(mocker: MockFixture, tmp_path):
     mocker.patch('cpg_flow.metamist.Metamist.get_analyses_by_sgid', mock_get_analysis_by_sgs)
     # don't patch the method location, patch where it's imported/called
     mocker.patch('cpg_flow.inputs.get_cohort_sgs', mock_get_cohorts)
+    mocker.patch('cpg_flow.inputs.check_for_inactive_cohorts', mock_give_args_get_none)
 
     from cpg_flow.inputs import get_multicohort
 
@@ -143,6 +147,7 @@ def test_overlapping_multicohort(mocker: MockFixture, tmp_path):
     mocker.patch('cpg_flow.metamist.Metamist.get_ped_entries', mock_get_pedigree)
     mocker.patch('cpg_flow.metamist.Metamist.get_analyses_by_sgid', mock_get_analysis_by_sgs)
     mocker.patch('cpg_flow.inputs.get_cohort_sgs', mock_get_overlapping_cohorts)
+    mocker.patch('cpg_flow.inputs.check_for_inactive_cohorts', mock_give_args_get_none)
 
     from cpg_flow.inputs import get_multicohort
 
@@ -190,6 +195,7 @@ def test_multicohort_dataset_config(mocker: MockFixture, tmp_path):
     mocker.patch('cpg_flow.metamist.Metamist.get_analyses_by_sgid', mock_get_analysis_by_sgs)
     # mockup the cohort data with '-test' suffix
     mocker.patch('cpg_flow.inputs.get_cohort_sgs', mock_get_test_project_cohorts)
+    mocker.patch('cpg_flow.inputs.check_for_inactive_cohorts', mock_give_args_get_none)
 
     from cpg_flow.inputs import get_multicohort
 
@@ -213,3 +219,55 @@ def test_multicohort_dataset_config(mocker: MockFixture, tmp_path):
     assert multicohort.get_sequencing_groups()[1].dataset.name == 'projecta'
     assert multicohort.get_sequencing_groups()[2].dataset.name == 'projectb'
     assert multicohort.get_sequencing_groups()[3].dataset.name == 'projectb'
+
+
+def mock_query_get_analysis_query_returns_one_analysis_one_sg(*args, **kwargs):
+    """
+    Mock function for AnalysisApi.query(GET_ANALYSES_QUERY) as sucess.
+    It returns valid analyses data.
+    where type and status are derived from the input kwargs.
+    """
+    return {
+        'project': {
+            'analyses': [
+                {
+                    'id': 12345,
+                    'type': kwargs.get('variables', {}).get('analysis_type', None),
+                    'meta': {},
+                    'output': 'test_output',
+                    'status': kwargs.get('variables', {}).get('analysis_status', None),
+                    'sequencingGroups': [{'id': 'SG01'}],
+                },
+            ],
+        },
+    }
+
+
+def test_check_invalid_cohorts(mocker: MockFixture, tmp_path, caplog):
+    cohort_list = ['COH1', 'COH2']
+    set_config(_multicohort_config(tmp_path, cohort_list), tmp_path / 'config.toml')
+
+    def mock_query(query, variables):
+        return load_mock_data('tests/assets/test_multicohort/cohort_check_bad.json')
+
+    mocker.patch(
+        'cpg_flow.metamist.query',
+        mock_query,
+    )
+    with pytest.raises(MetamistError):
+        check_for_inactive_cohorts(cohort_list)
+        assert f'Inactive Cohorts: {["COH2"]}' in caplog.text
+
+
+def test_check_valid_cohorts(mocker: MockFixture, tmp_path, caplog):
+    cohort_list = ['COH1', 'COH2']
+    set_config(_multicohort_config(tmp_path, cohort_list), tmp_path / 'config.toml')
+
+    def mock_query(query, variables):
+        return load_mock_data('tests/assets/test_multicohort/cohort_check_good.json')
+
+    mocker.patch(
+        'cpg_flow.metamist.query',
+        mock_query,
+    )
+    check_for_inactive_cohorts(cohort_list)

--- a/tests/test_multicohort.py
+++ b/tests/test_multicohort.py
@@ -221,28 +221,6 @@ def test_multicohort_dataset_config(mocker: MockFixture, tmp_path):
     assert multicohort.get_sequencing_groups()[3].dataset.name == 'projectb'
 
 
-def mock_query_get_analysis_query_returns_one_analysis_one_sg(*args, **kwargs):
-    """
-    Mock function for AnalysisApi.query(GET_ANALYSES_QUERY) as sucess.
-    It returns valid analyses data.
-    where type and status are derived from the input kwargs.
-    """
-    return {
-        'project': {
-            'analyses': [
-                {
-                    'id': 12345,
-                    'type': kwargs.get('variables', {}).get('analysis_type', None),
-                    'meta': {},
-                    'output': 'test_output',
-                    'status': kwargs.get('variables', {}).get('analysis_status', None),
-                    'sequencingGroups': [{'id': 'SG01'}],
-                },
-            ],
-        },
-    }
-
-
 def test_check_invalid_cohorts(mocker: MockFixture, tmp_path, caplog):
     cohort_list = ['COH1', 'COH2']
     set_config(_multicohort_config(tmp_path, cohort_list), tmp_path / 'config.toml')


### PR DESCRIPTION
Recently we made a change to the active status of Cohorts - there is now a runtime check per Cohort to see if it is 'active'. If a single SequencingGroup in a Cohort is not active, the whole Cohort is marked as invalid, and the pipeline will halt ([code](https://github.com/populationgenomics/cpg-flow/blob/main/src/cpg_flow/metamist.py#L536-L539))

The issue is that with large numbers of input cohorts (e.g. seqr-loader workflow containing >20 cohorts) this can lead to a cycle of run > fail > update failing cohort > run > fail... as the pipeline fails at the point a single cohort is found to be inactive, and doesn't check the others (which may also contain failures).

This PR proposes a skinny metamist query, taking the list of input cohorts and does an initial validation that all of the input cohorts are valid. A list of all invalid cohorts is kept, and if the pipeline will fail downstream of this check (one or more invalid cohorts) it fails here, printing the ID of all cohorts which need to be updated/replaced.

I should write a test for this, but wanted to post this for opinions.