### PR TITLE
fix(target.py): default to sg_hash

### DIFF
--- a/src/cpg_flow/targets/target.py
+++ b/src/cpg_flow/targets/target.py
@@ -37,6 +37,8 @@ Targets for workflow stages: SequencingGroup, Dataset, Cohort.
 import hashlib
 from typing import TYPE_CHECKING
 
+from cpg_utils.config import config_retrieve
+
 if TYPE_CHECKING:
     from cpg_flow.targets import SequencingGroup
 
@@ -95,12 +97,19 @@ class Target:
         """
         Unique hash string of sample alignment inputs. Useful to decide
         whether the analysis on the target needs to be rerun.
+
+        As we no longer populate alignment inputs for all workflows, this hash is now conditional
+        - if assay metadata is populated, hash of sequencing inputs
+        - if not, the Target's SG hash (same logic, but for CPG IDs, not fastq paths)
         """
-        s = ' '.join(
-            sorted(' '.join(str(s.alignment_input)) for s in self.get_sequencing_groups() if s.alignment_input),
-        )
-        h = hashlib.sha256(s.encode()).hexdigest()[:38]
-        self.alignment_inputs_hash = f'{h}_{len(self.get_sequencing_group_ids())}'
+        if config_retrieve(['workflow', 'populate_assays'], False):
+            s = ' '.join(
+                sorted(' '.join(str(s.alignment_input)) for s in self.get_sequencing_groups() if s.alignment_input),
+            )
+            h = hashlib.sha256(s.encode()).hexdigest()[:38]
+            self.alignment_inputs_hash = f'{h}_{len(self.get_sequencing_group_ids())}'
+        else:
+            self.alignment_inputs_hash = self.get_sg_hash()
 
     def get_sg_hash(self) -> str:
         """If the SG hash was generated, return it, otherwise generate and return it."""

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -84,15 +84,18 @@ def test_workflow(tmp_path: pathlib.Path):
 
     assert len(multi_cohort.get_sequencing_groups()) == 2
 
-    assert multi_cohort.alignment_inputs_hash is None
-    mc_hash = multi_cohort.get_alignment_inputs_hash()
-    assert multi_cohort.alignment_inputs_hash == mc_hash
-    assert mc_hash == 'e3b0c44298fc1c149afbf4c8996fb92427ae41_2'
+    expected_cpg_id_hash = '5ecfbcb86b94df30ddb6b9d4cfe3e3f49c31a3_2'
 
     assert multi_cohort.sg_hash is None
     mc_sg_hash = multi_cohort.get_sg_hash()
     assert multi_cohort.sg_hash == mc_sg_hash
-    assert mc_sg_hash == '5ecfbcb86b94df30ddb6b9d4cfe3e3f49c31a3_2'
+    assert mc_sg_hash == expected_cpg_id_hash
+
+    # this must come second, as the no-assay scenario populates the sg_hash
+    assert multi_cohort.alignment_inputs_hash is None
+    mc_hash = multi_cohort.get_alignment_inputs_hash()
+    assert multi_cohort.alignment_inputs_hash == mc_hash
+    assert mc_hash == expected_cpg_id_hash
 
     @stage
     class MySequencingGroupStage(SequencingGroupStage):


### PR DESCRIPTION
Same fix as #145 

Since we no longer populate the FastQs for each sample in the workflow setup (to reduce query times), we no longer have 'alignment inputs'.

As a result, each target's `alignment_inputs_hash` is a hash of an empty String, plus the size of the Target's SG pool.

This results in a near-same hash being applied to all targets: `e3b0c44298fc1c149afbf4c8996fb92427ae41_<number>`

This change matches the logic in #145 - unless the workflow is set up with assays, build this string by hashing the CPG IDs, not the FastQ file paths

---

Had to fix a failing test 🙃 the test required/checked against the value which we now know is a hash of an empty string