### PR TITLE
Upgrade to hail 138

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:latest
+FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Set up working directory for the project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ license-files = ["LICENSE"]
 version = "1.3.1"
 dependencies = [
     "cpg-utils>=5.4.2",
-    # Pin Hail at CPG"s installed version
-    "hail==0.2.137",
+    # Loose pin Hail at CPG"s installed version or higher
+    "hail~=0.2.137",
     "grpcio>=1.53.0",
     # Avoid dependency resolution backtracking, Python 3.10 compatibility
     "grpcio-status>=1.48,<1.79",
@@ -22,7 +22,6 @@ dependencies = [
     "pyyaml>=6.0.2",
     "plotly>=5.24.1",
     "ipywidgets>=8.1.5",
-    "pre-commit>=4.0.1",
     # Security adjustments
     "tornado>=6.5",
 ]
@@ -53,8 +52,8 @@ dev = [
     "black>=24.10.0",
     "build>=1.2.2.post1",
     "coverage>=7.6.4",
-    "hail>=0.2.133",
     "pip-audit>=2.7.3",
+    "pre-commit>=4.0.1",
     "pylint>=3.3.1",
     "pytest-mock>=3.14.0",
     "pytest>=8.3.3",
@@ -68,7 +67,6 @@ dev = [
     "mike>=2.1.3",
     "pyright>=1.1.400",
 ]
-
 
 [project.urls]
 Repository = "https://github.com/populationgenomics/cpg-flow"

--- a/src/cpg_flow/metamist.py
+++ b/src/cpg_flow/metamist.py
@@ -535,7 +535,7 @@ def check_for_inactive_cohorts(cohort_ids: list[str]) -> None:
 
     invalid_cohorts: list[str] = []
 
-    for cohort_result in result['data']['cohorts']:
+    for cohort_result in result['cohorts']:
         if cohort_result['status'] != 'active':
             invalid_cohorts.append(cohort_result['id'])
 

--- a/tests/assets/test_multicohort/cohort_check_bad.json
+++ b/tests/assets/test_multicohort/cohort_check_bad.json
@@ -1,14 +1,12 @@
 {
-  "data": {
-    "cohorts": [
-      {
-        "id": "COH1",
-        "status": "active"
-      },
-      {
-        "id": "COH2",
-        "status": "invalid"
-      }
-    ]
-  }
+  "cohorts": [
+    {
+      "id": "COH1",
+      "status": "active"
+    },
+    {
+      "id": "COH2",
+      "status": "invalid"
+    }
+  ]
 }

--- a/tests/assets/test_multicohort/cohort_check_good.json
+++ b/tests/assets/test_multicohort/cohort_check_good.json
@@ -1,14 +1,12 @@
 {
-  "data": {
-    "cohorts": [
-      {
-        "id": "COH1",
-        "status": "active"
-      },
-      {
-        "id": "COH2",
-        "status": "active"
-      }
-    ]
-  }
+  "cohorts": [
+    {
+      "id": "COH1",
+      "status": "active"
+    },
+    {
+      "id": "COH2",
+      "status": "active"
+    }
+  ]
 }


### PR DESCRIPTION
Bump to use the cpg-hail base image (should run the same but with much smaller resulting images)

Loosens the Hail pin from ==137 to >=137 so we don't have to keep doing this

Removes a redundant Hail dependency

---

Also corrects a bug I left in the code during the last PR 👀 