### PR TITLE
avoid ARG_MAX overflow when passing SBOM to jq

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -47,13 +47,17 @@ jobs:
       - name: Upload SBOM to Dependency-Track
         env:
           TOKEN: ${{ steps.auth.outputs.id_token }}
+          DTRACK_API_KEY: ${{ secrets.DTRACK_API_KEY }}
           PROJECT_NAME: ${{ github.event.repository.name }}
           PROJECT_VERSION: ${{ steps.version.outputs.value }}
         run: |
+            # Stream the SBOM through a file + --rawfile to avoid the
+            # ARG_MAX limit hit when passing it inline via --arg.
+            base64 -w0 sbom.cdx.json > sbom.b64
             jq -n \
               --arg name "$PROJECT_NAME" \
               --arg version "$PROJECT_VERSION" \
-              --arg bom "$(base64 -w0 sbom.cdx.json)" \
+              --rawfile bom sbom.b64 \
               --arg ref "$GITHUB_REF_NAME" \
               '{
                 projectName: $name,
@@ -67,6 +71,6 @@ jobs:
               }' | \
             curl -sf -X PUT "https://dtrack.popgen.rocks/api/v1/bom" \
               -H "Authorization: Bearer $TOKEN" \
-              -H "X-Api-Key: ${{ secrets.DTRACK_API_KEY }}" \
+              -H "X-Api-Key: $DTRACK_API_KEY" \
               -H "Content-Type: application/json" \
               -d @-

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: populationgenomics/python-package-scanner@7db0863f7646dcd34df1ee5f2911149f67628eb3 # v0
+      - uses: populationgenomics/python-package-scanner@1996135cf0e2a2c1e06b242f8eb99b65365da6a0 # v0
         with:
           mode: uv
           fail-on-vulns: true

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: populationgenomics/python-package-scanner@1996135cf0e2a2c1e06b242f8eb99b65365da6a0 # v0
+      - uses: populationgenomics/python-package-scanner@7565101b3af83600ce32260e5e70755bf80f6ee4 # v0
         with:
           mode: uv
           fail-on-vulns: true


### PR DESCRIPTION
## Summary
- The SBOM upload step was failing with `/usr/bin/jq: Argument list too long` because the entire base64-encoded CycloneDX SBOM was passed inline via `jq --arg bom "$(base64 -w0 sbom.cdx.json)"`. Once the SBOM is large enough, the expanded argument blows past Linux's `ARG_MAX` (~128 KB combined with other args + env).
- Fix: write the base64 output to a temp file and use `jq --rawfile bom sbom.b64`, which reads the file contents directly into the variable without going through the argument list.
- Also moves the Dependency-Track API key from inline `${{ secrets.DTRACK_API_KEY }}` interpolation into the `env:` block, so the secret is never expanded into the shell script body.
- Also bumps `python-package-scanner` to a newer version for better audit reporting

See: https://github.com/populationgenomics/cpg-flow/actions/runs/25297552405